### PR TITLE
updates card image paths.

### DIFF
--- a/packs/2T2D.json
+++ b/packs/2T2D.json
@@ -39,7 +39,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10055",
             "value": "",
             "url": "https://dtdb.co/en/card/20001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20001.jpg"
+            "imagesrc": "/images/cards/en/20001.jpg"
         },
         {
             "last-modified": "2018-06-02T22:19:33+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10053",
             "value": "",
             "url": "https://dtdb.co/en/card/20002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20002.jpg"
+            "imagesrc": "/images/cards/en/20002.jpg"
         },
         {
             "last-modified": "2018-07-03T15:05:05+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10056",
             "value": "",
             "url": "https://dtdb.co/en/card/20003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20003.jpg"
+            "imagesrc": "/images/cards/en/20003.jpg"
         },
         {
             "last-modified": "2018-06-02T22:21:54+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10005",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/20004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20004.jpg"
+            "imagesrc": "/images/cards/en/20004.jpg"
         },
         {
             "last-modified": "2018-03-20T11:09:09+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10004",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/20005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20005.jpg"
+            "imagesrc": "/images/cards/en/20005.jpg"
         },
         {
             "last-modified": "2018-03-20T11:08:19+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10003",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/20006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20006.jpg"
+            "imagesrc": "/images/cards/en/20006.jpg"
         },
         {
             "last-modified": "2018-03-20T11:07:07+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10001",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/20007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20007.jpg"
+            "imagesrc": "/images/cards/en/20007.jpg"
         },
         {
             "last-modified": "2018-07-03T16:04:03+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10002",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/20008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20008.jpg"
+            "imagesrc": "/images/cards/en/20008.jpg"
         },
         {
             "last-modified": "2018-06-02T20:19:47+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10006",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/20009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20009.jpg"
+            "imagesrc": "/images/cards/en/20009.jpg"
         },
         {
             "last-modified": "2018-03-20T11:15:40+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10010",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/20010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20010.jpg"
+            "imagesrc": "/images/cards/en/20010.jpg"
         },
         {
             "last-modified": "2018-07-03T16:04:45+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10009",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/20011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20011.jpg"
+            "imagesrc": "/images/cards/en/20011.jpg"
         },
         {
             "last-modified": "2018-03-20T11:13:54+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10008",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/20012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20012.jpg"
+            "imagesrc": "/images/cards/en/20012.jpg"
         },
         {
             "last-modified": "2018-06-02T20:22:07+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10007",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/20013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20013.jpg"
+            "imagesrc": "/images/cards/en/20013.jpg"
         },
         {
             "last-modified": "2018-06-02T20:24:43+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10019",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/20014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20014.jpg"
+            "imagesrc": "/images/cards/en/20014.jpg"
         },
         {
             "last-modified": "2018-03-20T11:30:03+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10022",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/20015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20015.jpg"
+            "imagesrc": "/images/cards/en/20015.jpg"
         },
         {
             "last-modified": "2018-06-02T20:26:18+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10021",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/20016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20016.jpg"
+            "imagesrc": "/images/cards/en/20016.jpg"
         },
         {
             "last-modified": "2018-04-12T23:39:16+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10020",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/20017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20017.jpg"
+            "imagesrc": "/images/cards/en/20017.jpg"
         },
         {
             "last-modified": "2018-03-21T17:10:05+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10011",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/20018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20018.jpg"
+            "imagesrc": "/images/cards/en/20018.jpg"
         },
         {
             "last-modified": "2018-03-20T11:20:12+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10013",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/20019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20019.jpg"
+            "imagesrc": "/images/cards/en/20019.jpg"
         },
         {
             "last-modified": "2018-06-02T20:27:49+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10012",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/20020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20020.jpg"
+            "imagesrc": "/images/cards/en/20020.jpg"
         },
         {
             "last-modified": "2018-06-02T20:30:01+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10014",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/20021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20021.jpg"
+            "imagesrc": "/images/cards/en/20021.jpg"
         },
         {
             "last-modified": "2018-06-02T20:31:58+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10017",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/20022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20022.jpg"
+            "imagesrc": "/images/cards/en/20022.jpg"
         },
         {
             "last-modified": "2018-06-02T20:33:57+02:00",
@@ -765,7 +765,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10016",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/20023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20023.jpg"
+            "imagesrc": "/images/cards/en/20023.jpg"
         },
         {
             "last-modified": "2018-03-20T11:24:12+01:00",
@@ -798,7 +798,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10018",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/20024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20024.jpg"
+            "imagesrc": "/images/cards/en/20024.jpg"
         },
         {
             "last-modified": "2018-03-20T11:21:42+01:00",
@@ -831,7 +831,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10015",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/20025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20025.jpg"
+            "imagesrc": "/images/cards/en/20025.jpg"
         },
         {
             "last-modified": "2018-06-02T20:36:27+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10024",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/20026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20026.jpg"
+            "imagesrc": "/images/cards/en/20026.jpg"
         },
         {
             "last-modified": "2018-07-03T16:11:57+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10023",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/20027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20027.jpg"
+            "imagesrc": "/images/cards/en/20027.jpg"
         },
         {
             "last-modified": "2019-05-10T21:09:09+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10026",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/20028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20028.jpg"
+            "imagesrc": "/images/cards/en/20028.jpg"
         },
         {
             "last-modified": "2018-06-02T20:38:10+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10025",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/20029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20029.jpg"
+            "imagesrc": "/images/cards/en/20029.jpg"
         },
         {
             "last-modified": "2018-06-02T20:39:41+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10027",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/20030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20030.jpg"
+            "imagesrc": "/images/cards/en/20030.jpg"
         },
         {
             "last-modified": "2018-04-12T23:47:15+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10032",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/20031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20031.jpg"
+            "imagesrc": "/images/cards/en/20031.jpg"
         },
         {
             "last-modified": "2018-07-05T02:40:54+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10030",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/20032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20032.jpg"
+            "imagesrc": "/images/cards/en/20032.jpg"
         },
         {
             "last-modified": "2018-06-02T20:41:15+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10029",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/20033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20033.jpg"
+            "imagesrc": "/images/cards/en/20033.jpg"
         },
         {
             "last-modified": "2018-06-02T22:42:40+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10033",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/20034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20034.jpg"
+            "imagesrc": "/images/cards/en/20034.jpg"
         },
         {
             "last-modified": "2018-04-12T23:46:31+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10028",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/20035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20035.jpg"
+            "imagesrc": "/images/cards/en/20035.jpg"
         },
         {
             "last-modified": "2018-06-02T20:42:45+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10031",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/20036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20036.jpg"
+            "imagesrc": "/images/cards/en/20036.jpg"
         },
         {
             "last-modified": "2018-03-20T12:16:29+01:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10034",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/20037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20037.jpg"
+            "imagesrc": "/images/cards/en/20037.jpg"
         },
         {
             "last-modified": "2018-04-28T03:10:17+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10038",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/20038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20038.jpg"
+            "imagesrc": "/images/cards/en/20038.jpg"
         },
         {
             "last-modified": "2018-07-03T16:35:59+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10036",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/20039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20039.jpg"
+            "imagesrc": "/images/cards/en/20039.jpg"
         },
         {
             "last-modified": "2018-07-03T15:58:45+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10039",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/20040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20040.jpg"
+            "imagesrc": "/images/cards/en/20040.jpg"
         },
         {
             "last-modified": "2018-06-02T20:50:26+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10035",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/20041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20041.jpg"
+            "imagesrc": "/images/cards/en/20041.jpg"
         },
         {
             "last-modified": "2018-04-28T03:10:45+02:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10037",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/20042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20042.jpg"
+            "imagesrc": "/images/cards/en/20042.jpg"
         },
         {
             "last-modified": "2018-06-02T20:51:47+02:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10041",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/20043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20043.jpg"
+            "imagesrc": "/images/cards/en/20043.jpg"
         },
         {
             "last-modified": "2018-06-20T17:51:19+02:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10045",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/20044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20044.jpg"
+            "imagesrc": "/images/cards/en/20044.jpg"
         },
         {
             "last-modified": "2018-03-21T11:37:43+01:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10044",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/20045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20045.jpg"
+            "imagesrc": "/images/cards/en/20045.jpg"
         },
         {
             "last-modified": "2018-06-02T20:53:28+02:00",
@@ -1524,7 +1524,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10040",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/20046",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20046.jpg"
+            "imagesrc": "/images/cards/en/20046.jpg"
         },
         {
             "last-modified": "2018-03-20T12:27:02+01:00",
@@ -1557,7 +1557,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10042",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/20047",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20047.jpg"
+            "imagesrc": "/images/cards/en/20047.jpg"
         },
         {
             "last-modified": "2018-06-02T20:54:50+02:00",
@@ -1590,7 +1590,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10043",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/20048",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20048.jpg"
+            "imagesrc": "/images/cards/en/20048.jpg"
         },
         {
             "last-modified": "2018-06-02T20:56:15+02:00",
@@ -1623,7 +1623,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10051",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/20049",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20049.jpg"
+            "imagesrc": "/images/cards/en/20049.jpg"
         },
         {
             "last-modified": "2018-03-21T11:42:26+01:00",
@@ -1656,7 +1656,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10050",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/20050",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20050.jpg"
+            "imagesrc": "/images/cards/en/20050.jpg"
         },
         {
             "last-modified": "2018-06-02T20:58:26+02:00",
@@ -1689,7 +1689,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10054",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/20051",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20051.jpg"
+            "imagesrc": "/images/cards/en/20051.jpg"
         },
         {
             "last-modified": "2018-06-02T21:02:10+02:00",
@@ -1722,7 +1722,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10048",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/20052",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20052.jpg"
+            "imagesrc": "/images/cards/en/20052.jpg"
         },
         {
             "last-modified": "2018-06-02T21:04:57+02:00",
@@ -1755,7 +1755,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10047",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/20053",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20053.jpg"
+            "imagesrc": "/images/cards/en/20053.jpg"
         },
         {
             "last-modified": "2018-06-02T21:12:42+02:00",
@@ -1788,7 +1788,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10052",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/20054",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20054.jpg"
+            "imagesrc": "/images/cards/en/20054.jpg"
         },
         {
             "last-modified": "2018-06-02T21:14:27+02:00",
@@ -1821,7 +1821,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10046",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/20055",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20055.jpg"
+            "imagesrc": "/images/cards/en/20055.jpg"
         },
         {
             "last-modified": "2018-03-21T11:41:46+01:00",
@@ -1854,7 +1854,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429c10049",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/20056",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/20056.jpg"
+            "imagesrc": "/images/cards/en/20056.jpg"
         }
     ]
 }

--- a/packs/AGE.json
+++ b/packs/AGE.json
@@ -39,7 +39,7 @@
             "octgnid": "8c1e6faf-c90d-4167-9834-793ffcaa47f7",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/16001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16001.jpg"
+            "imagesrc": "/images/cards/en/16001.jpg"
         },
         {
             "last-modified": "2018-01-05T18:09:31+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "b1d4638a-0118-426f-a966-1a9c6ff0da5b",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/16002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16002.jpg"
+            "imagesrc": "/images/cards/en/16002.jpg"
         },
         {
             "last-modified": "2016-08-02T17:55:48+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "0c1b3abb-69eb-4f9b-9dfc-69942c2442a6",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/16003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16003.jpg"
+            "imagesrc": "/images/cards/en/16003.jpg"
         },
         {
             "last-modified": "2016-08-02T17:57:43+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "d2e8e560-15ad-421d-931b-7bb9a8bc6b2c",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/16004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16004.jpg"
+            "imagesrc": "/images/cards/en/16004.jpg"
         },
         {
             "last-modified": "2016-08-02T17:59:16+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "51b3db35-9811-4adf-89f6-7dd48b031bba",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/16005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16005.jpg"
+            "imagesrc": "/images/cards/en/16005.jpg"
         },
         {
             "last-modified": "2016-08-02T19:12:17+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "7477d1e2-14c6-45e8-8acd-9619ec2fa578",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/16006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16006.jpg"
+            "imagesrc": "/images/cards/en/16006.jpg"
         },
         {
             "last-modified": "2016-08-02T19:13:32+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "314f6ee6-e572-44a2-9412-78bd822be671",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/16007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16007.jpg"
+            "imagesrc": "/images/cards/en/16007.jpg"
         },
         {
             "last-modified": "2016-08-02T19:15:05+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "1120919a-d4b6-4655-b369-4f732b016e14",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/16008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16008.jpg"
+            "imagesrc": "/images/cards/en/16008.jpg"
         },
         {
             "last-modified": "2016-08-02T19:16:18+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "be0ace53-d90a-4fff-a6a6-c5545667d83f",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/16009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16009.jpg"
+            "imagesrc": "/images/cards/en/16009.jpg"
         },
         {
             "last-modified": "2016-08-02T19:19:50+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "fd144b71-3727-4333-be79-b57ab4fe3afc",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/16010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16010.jpg"
+            "imagesrc": "/images/cards/en/16010.jpg"
         },
         {
             "last-modified": "2016-08-02T19:21:56+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "d03f58a7-ef6a-428e-a950-67e0b6245b66",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/16011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16011.jpg"
+            "imagesrc": "/images/cards/en/16011.jpg"
         },
         {
             "last-modified": "2016-08-02T19:23:23+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "7cc6fca2-a48a-4386-ba79-2fd94534b6ec",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/16012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16012.jpg"
+            "imagesrc": "/images/cards/en/16012.jpg"
         },
         {
             "last-modified": "2016-08-02T19:25:11+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "4461e319-d77d-4a76-ba9c-e401a4a99223",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/16013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16013.jpg"
+            "imagesrc": "/images/cards/en/16013.jpg"
         },
         {
             "last-modified": "2016-08-02T19:28:54+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "2e323023-c293-41ce-a87c-12fddba592d5",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/16014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16014.jpg"
+            "imagesrc": "/images/cards/en/16014.jpg"
         },
         {
             "last-modified": "2016-08-02T19:43:33+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "af22f9d8-738b-4e7f-a13a-599089e51507",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/16015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16015.jpg"
+            "imagesrc": "/images/cards/en/16015.jpg"
         },
         {
             "last-modified": "2016-08-02T19:47:13+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "8b505b63-7954-42b6-b072-85b5b794c0fa",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/16016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16016.jpg"
+            "imagesrc": "/images/cards/en/16016.jpg"
         },
         {
             "last-modified": "2018-01-05T18:10:13+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "ba6d6429-9a34-4912-96c4-aee1649650f3",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/16017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16017.jpg"
+            "imagesrc": "/images/cards/en/16017.jpg"
         },
         {
             "last-modified": "2016-08-02T19:50:33+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "f8fc9a76-cbd9-4ad5-b2c7-5cd40f150e79",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/16018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16018.jpg"
+            "imagesrc": "/images/cards/en/16018.jpg"
         },
         {
             "last-modified": "2016-08-02T19:51:35+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "059481a6-d607-4896-8584-fb596c4647f7",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/16019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16019.jpg"
+            "imagesrc": "/images/cards/en/16019.jpg"
         },
         {
             "last-modified": "2018-01-05T18:11:14+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "49496e5f-974e-43f1-a85f-d9bda3de8325",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/16020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16020.jpg"
+            "imagesrc": "/images/cards/en/16020.jpg"
         },
         {
             "last-modified": "2016-08-02T19:57:38+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "18f82dad-6f87-4a26-9dee-2859b4854b70",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/16021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/16021.jpg"
+            "imagesrc": "/images/cards/en/16021.jpg"
         }
     ]
 }

--- a/packs/BMR.json
+++ b/packs/BMR.json
@@ -39,7 +39,7 @@
             "octgnid": "72f2f4f7-2e0e-4994-aaa2-c6228fc3d8d9",
             "value": "",
             "url": "https://dtdb.co/en/card/18001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18001.jpg"
+            "imagesrc": "/images/cards/en/18001.jpg"
         },
         {
             "last-modified": "2017-11-24T23:34:16+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "fd347528-2ce1-4cc5-9efb-a1052ee8603b",
             "value": "",
             "url": "https://dtdb.co/en/card/18002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18002.jpg"
+            "imagesrc": "/images/cards/en/18002.jpg"
         },
         {
             "last-modified": "2016-10-13T19:04:43+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "a9ec06b7-2fe5-4334-82f1-43e460b07967",
             "value": "",
             "url": "https://dtdb.co/en/card/18003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18003.jpg"
+            "imagesrc": "/images/cards/en/18003.jpg"
         },
         {
             "last-modified": "2017-11-24T23:35:40+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "e0943fa8-0024-451f-862f-644ee23011eb",
             "value": "",
             "url": "https://dtdb.co/en/card/18004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18004.jpg"
+            "imagesrc": "/images/cards/en/18004.jpg"
         },
         {
             "last-modified": "2016-10-13T19:06:55+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "b94ed693-16ed-4c7c-84d8-375498922a74",
             "value": "",
             "url": "https://dtdb.co/en/card/18005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18005.jpg"
+            "imagesrc": "/images/cards/en/18005.jpg"
         },
         {
             "last-modified": "2017-11-24T23:36:04+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "e415100e-91bb-4d9e-87aa-ec2f23d63f84",
             "value": "",
             "url": "https://dtdb.co/en/card/18006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18006.jpg"
+            "imagesrc": "/images/cards/en/18006.jpg"
         },
         {
             "last-modified": "2017-12-13T13:28:28+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "407fccf5-1007-4be6-a1f5-8a06bc2c0674",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/18007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18007.jpg"
+            "imagesrc": "/images/cards/en/18007.jpg"
         },
         {
             "last-modified": "2016-10-13T19:13:04+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "ef12ef9a-b1c8-433f-a4ac-eac38f5ffaf1",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/18008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18008.jpg"
+            "imagesrc": "/images/cards/en/18008.jpg"
         },
         {
             "last-modified": "2016-10-13T19:14:38+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "52674538-37bf-4dc3-bba9-164f11abb7c4",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/18009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18009.jpg"
+            "imagesrc": "/images/cards/en/18009.jpg"
         },
         {
             "last-modified": "2016-10-13T19:16:32+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "043e1e23-de64-403f-a5ae-6df84823538f",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/18010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18010.jpg"
+            "imagesrc": "/images/cards/en/18010.jpg"
         },
         {
             "last-modified": "2017-12-13T13:29:20+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "4e453b4b-da87-4042-8ebf-92ff9a25c25c",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/18011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18011.jpg"
+            "imagesrc": "/images/cards/en/18011.jpg"
         },
         {
             "last-modified": "2016-10-13T19:19:26+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "1c769e8e-e7d5-49e5-94c7-7f83dc3b1cc7",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/18012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18012.jpg"
+            "imagesrc": "/images/cards/en/18012.jpg"
         },
         {
             "last-modified": "2017-12-13T13:30:35+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "2431b33e-b34c-4b53-9915-fa18ca6777e7",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/18013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18013.jpg"
+            "imagesrc": "/images/cards/en/18013.jpg"
         },
         {
             "last-modified": "2016-10-13T19:22:30+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "75969ce9-d9e6-4cc1-b4e5-5ff29c3e8d69",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/18014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18014.jpg"
+            "imagesrc": "/images/cards/en/18014.jpg"
         },
         {
             "last-modified": "2016-10-13T19:24:08+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "c213a4b2-95ee-487c-b0a8-8cc09ac87a7d",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/18015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18015.jpg"
+            "imagesrc": "/images/cards/en/18015.jpg"
         },
         {
             "last-modified": "2016-10-13T19:25:43+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "77e140fc-3d2d-4715-bc47-af208e671b3e",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/18016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18016.jpg"
+            "imagesrc": "/images/cards/en/18016.jpg"
         },
         {
             "last-modified": "2017-12-13T13:29:53+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "82aaf3b6-9eb1-4fd2-9812-b6b727cf51b2",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/18017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18017.jpg"
+            "imagesrc": "/images/cards/en/18017.jpg"
         },
         {
             "last-modified": "2018-01-05T18:12:23+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "03c922cf-e0ef-4d47-bbb7-7c62428f90fb",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/18018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18018.jpg"
+            "imagesrc": "/images/cards/en/18018.jpg"
         },
         {
             "last-modified": "2016-10-13T19:31:27+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "163fc3b6-eea4-44ab-9edc-f03647046c3a",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/18019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18019.jpg"
+            "imagesrc": "/images/cards/en/18019.jpg"
         },
         {
             "last-modified": "2017-12-13T13:37:19+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "2a6bafed-d2ea-4275-877a-f0f15aae4c85",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/18020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18020.jpg"
+            "imagesrc": "/images/cards/en/18020.jpg"
         },
         {
             "last-modified": "2017-12-13T13:32:22+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "543b1dab-41f2-4d79-80f5-a00fa3a0b6e8",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/18021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18021.jpg"
+            "imagesrc": "/images/cards/en/18021.jpg"
         },
         {
             "last-modified": "2016-10-13T19:36:10+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "581c842b-d83b-4fcf-b525-7acad7f4a866",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/18022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18022.jpg"
+            "imagesrc": "/images/cards/en/18022.jpg"
         },
         {
             "last-modified": "2017-12-13T13:33:11+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "15b1a170-e713-40d5-ab39-6ed2f8cd97d6",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/18023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18023.jpg"
+            "imagesrc": "/images/cards/en/18023.jpg"
         },
         {
             "last-modified": "2016-10-13T19:40:00+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "27194abd-3f50-4088-98f2-5dd70dfddd62",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/18024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18024.jpg"
+            "imagesrc": "/images/cards/en/18024.jpg"
         },
         {
             "last-modified": "2016-10-13T19:41:36+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "76f4b9dd-7c1e-4ffd-a2ea-e7e2d0f253eb",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/18025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18025.jpg"
+            "imagesrc": "/images/cards/en/18025.jpg"
         },
         {
             "last-modified": "2018-01-05T18:13:10+01:00",
@@ -864,7 +864,7 @@
             "octgnid": "d88d3c39-4f35-40e9-b37b-046f6c9409de",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/18026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18026.jpg"
+            "imagesrc": "/images/cards/en/18026.jpg"
         },
         {
             "last-modified": "2018-01-05T18:17:19+01:00",
@@ -897,7 +897,7 @@
             "octgnid": "cb7e441a-1d78-4967-92ec-ab2d3a0f70fe",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/18027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18027.jpg"
+            "imagesrc": "/images/cards/en/18027.jpg"
         },
         {
             "last-modified": "2016-10-13T19:47:29+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "86f8e98c-66a6-4a54-b0c0-48e7428dc891",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/18028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18028.jpg"
+            "imagesrc": "/images/cards/en/18028.jpg"
         },
         {
             "last-modified": "2016-10-13T19:49:32+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "08507600-22ab-4903-861e-1c3941a54e23",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/18029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18029.jpg"
+            "imagesrc": "/images/cards/en/18029.jpg"
         },
         {
             "last-modified": "2016-10-13T19:51:00+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "765bff12-2d2b-44a0-a5ad-80920e291833",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/18030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18030.jpg"
+            "imagesrc": "/images/cards/en/18030.jpg"
         },
         {
             "last-modified": "2016-10-13T19:52:09+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "a12b3e09-b8af-4620-8479-20b5065df197",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/18031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18031.jpg"
+            "imagesrc": "/images/cards/en/18031.jpg"
         },
         {
             "last-modified": "2016-10-13T19:53:03+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "540d789b-98d5-47ac-8778-7a834851b10b",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/18032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18032.jpg"
+            "imagesrc": "/images/cards/en/18032.jpg"
         },
         {
             "last-modified": "2017-12-13T13:41:15+01:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "1cd6c83a-2c5d-4f23-92d3-f9dd371413f0",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/18033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18033.jpg"
+            "imagesrc": "/images/cards/en/18033.jpg"
         },
         {
             "last-modified": "2017-12-13T13:42:00+01:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "973b1148-56aa-421b-ba9a-5c6273710b6c",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/18034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18034.jpg"
+            "imagesrc": "/images/cards/en/18034.jpg"
         },
         {
             "last-modified": "2016-10-13T19:56:26+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "3448fa9e-1adc-4094-80a9-7c2ed35db597",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/18035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18035.jpg"
+            "imagesrc": "/images/cards/en/18035.jpg"
         },
         {
             "last-modified": "2017-12-13T13:40:24+01:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "e4118ee1-a9eb-4738-a378-673ca6c918a7",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/18036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18036.jpg"
+            "imagesrc": "/images/cards/en/18036.jpg"
         },
         {
             "last-modified": "2016-10-13T19:58:13+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "39fa07ab-40d4-4ddd-b2a6-6c444a1f48cd",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/18037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18037.jpg"
+            "imagesrc": "/images/cards/en/18037.jpg"
         },
         {
             "last-modified": "2016-10-13T19:59:09+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "ea3990fa-ae15-4314-b8f7-d4d8aaf11788",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/18038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18038.jpg"
+            "imagesrc": "/images/cards/en/18038.jpg"
         },
         {
             "last-modified": "2017-12-13T13:43:04+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "eaf25cb8-16fb-4f52-ba4b-ce8a88295d2f",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/18039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18039.jpg"
+            "imagesrc": "/images/cards/en/18039.jpg"
         },
         {
             "last-modified": "2016-10-13T20:00:32+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "a149d4e1-b28c-4f5a-8202-9c12d7be2876",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/18040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18040.jpg"
+            "imagesrc": "/images/cards/en/18040.jpg"
         },
         {
             "last-modified": "2016-10-24T18:56:58+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "1c4fd81f-8b08-4e7f-9325-8c63104f2694",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/18041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18041.jpg"
+            "imagesrc": "/images/cards/en/18041.jpg"
         },
         {
             "last-modified": "2017-12-13T13:55:38+01:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "698ae5b9-1b37-45be-bbd2-118c03d64a30",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/18042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/18042.jpg"
+            "imagesrc": "/images/cards/en/18042.jpg"
         }
     ]
 }

--- a/packs/BadM.json
+++ b/packs/BadM.json
@@ -39,7 +39,7 @@
             "octgnid": "e54fe16d-a197-4461-9309-42718820a294",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/13001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13001.jpg"
+            "imagesrc": "/images/cards/en/13001.jpg"
         },
         {
             "last-modified": "2016-02-02T20:04:07+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "12bea32a-b544-47e8-b2c7-4355aa1606ac",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/13002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13002.jpg"
+            "imagesrc": "/images/cards/en/13002.jpg"
         },
         {
             "last-modified": "2016-02-02T20:05:36+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "5126c19e-76f4-4355-8dad-8023adab95e7",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/13003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13003.jpg"
+            "imagesrc": "/images/cards/en/13003.jpg"
         },
         {
             "last-modified": "2016-02-02T20:07:04+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "1a69a29f-8d3e-4b90-a4b0-8050855974df",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/13004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13004.jpg"
+            "imagesrc": "/images/cards/en/13004.jpg"
         },
         {
             "last-modified": "2016-02-02T20:08:22+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "b791fa54-dbe2-4cda-90dd-91a0df866ed1",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/13005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13005.jpg"
+            "imagesrc": "/images/cards/en/13005.jpg"
         },
         {
             "last-modified": "2016-02-02T20:09:57+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "20ff3990-e458-4fe7-a8c3-8f7839430e73",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/13006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13006.jpg"
+            "imagesrc": "/images/cards/en/13006.jpg"
         },
         {
             "last-modified": "2016-02-02T20:11:01+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "06798ab4-80bd-4497-b6fe-d2093c788ba8",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/13007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13007.jpg"
+            "imagesrc": "/images/cards/en/13007.jpg"
         },
         {
             "last-modified": "2016-02-02T20:43:20+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "55c7c4fb-53ee-4fef-96f2-666ef2f1ec2d",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/13008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13008.jpg"
+            "imagesrc": "/images/cards/en/13008.jpg"
         },
         {
             "last-modified": "2016-02-02T20:13:52+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "198921ba-aafd-4379-bf9d-205b4a4c7763",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/13009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13009.jpg"
+            "imagesrc": "/images/cards/en/13009.jpg"
         },
         {
             "last-modified": "2016-02-02T20:15:50+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "4be0dce0-1671-4ac1-9539-d721e8fa5b34",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/13010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13010.jpg"
+            "imagesrc": "/images/cards/en/13010.jpg"
         },
         {
             "last-modified": "2016-02-02T20:16:54+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "6d816729-b023-4801-8aee-426ebe657835",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/13011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13011.jpg"
+            "imagesrc": "/images/cards/en/13011.jpg"
         },
         {
             "last-modified": "2016-02-02T20:18:19+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "c9534712-af16-422c-8fb5-dac7b8c82c65",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/13012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13012.jpg"
+            "imagesrc": "/images/cards/en/13012.jpg"
         },
         {
             "last-modified": "2016-02-02T20:19:35+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "f316fc32-d8a7-4810-bb75-7c1491058ad8",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/13013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13013.jpg"
+            "imagesrc": "/images/cards/en/13013.jpg"
         },
         {
             "last-modified": "2016-02-02T20:43:08+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "3347bf9b-ca97-4625-8409-521a4b90af3e",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/13014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13014.jpg"
+            "imagesrc": "/images/cards/en/13014.jpg"
         },
         {
             "last-modified": "2016-02-02T20:21:56+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "2fb05302-5326-458a-81bf-c5ad611e63e1",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/13015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13015.jpg"
+            "imagesrc": "/images/cards/en/13015.jpg"
         },
         {
             "last-modified": "2016-02-02T20:43:00+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "8aad1d23-54ea-4439-8d94-e84b1c283d67",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/13016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13016.jpg"
+            "imagesrc": "/images/cards/en/13016.jpg"
         },
         {
             "last-modified": "2016-05-12T20:22:08+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "5d7757ad-32cf-4383-959e-594e8a7314be",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/13017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13017.jpg"
+            "imagesrc": "/images/cards/en/13017.jpg"
         },
         {
             "last-modified": "2016-02-23T20:44:23+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "614b4a5f-6a75-4a4d-af99-269ce0c53375",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/13018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13018.jpg"
+            "imagesrc": "/images/cards/en/13018.jpg"
         },
         {
             "last-modified": "2017-03-25T11:41:59+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "1ba6917a-9efe-4e3e-a118-3270e1c36854",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/13019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13019.jpg"
+            "imagesrc": "/images/cards/en/13019.jpg"
         },
         {
             "last-modified": "2016-02-02T20:42:49+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "2d728020-2cf6-4908-8034-7325e9fcb394",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/13020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13020.jpg"
+            "imagesrc": "/images/cards/en/13020.jpg"
         },
         {
             "last-modified": "2016-05-12T20:29:43+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "b046d41f-0b5c-4c0c-8d71-507c7877807e",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/13021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/13021.jpg"
+            "imagesrc": "/images/cards/en/13021.jpg"
         }
     ]
 }

--- a/packs/DD.json
+++ b/packs/DD.json
@@ -39,7 +39,7 @@
             "octgnid": "90b3fbde-2834-4c49-9577-1d8723feadd4",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/03001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03001.jpg"
+            "imagesrc": "/images/cards/en/03001.jpg"
         },
         {
             "last-modified": "2015-10-03T12:03:03+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "68b6d3d2-207c-47ed-9311-0949f86308b9",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/03002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03002.jpg"
+            "imagesrc": "/images/cards/en/03002.jpg"
         },
         {
             "last-modified": "2015-10-03T12:03:47+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "e0434a23-02b1-406b-a683-0b230b73111d",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/03003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03003.jpg"
+            "imagesrc": "/images/cards/en/03003.jpg"
         },
         {
             "last-modified": "2015-09-28T19:51:22+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "631a3c9a-b970-47f5-a196-c078ad913d56",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/03004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03004.jpg"
+            "imagesrc": "/images/cards/en/03004.jpg"
         },
         {
             "last-modified": "2015-09-28T20:16:48+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "434353cb-3040-4709-a7d5-e4f36006128b",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/03005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03005.jpg"
+            "imagesrc": "/images/cards/en/03005.jpg"
         },
         {
             "last-modified": "2015-10-03T12:04:17+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "17760a8d-adc3-40cc-9c85-578b7f2b30c5",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/03006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03006.jpg"
+            "imagesrc": "/images/cards/en/03006.jpg"
         },
         {
             "last-modified": "2015-09-28T19:53:07+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "08fbd7c6-0413-4b5b-872e-a9ba16e3276d",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/03007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03007.jpg"
+            "imagesrc": "/images/cards/en/03007.jpg"
         },
         {
             "last-modified": "2015-10-04T14:26:37+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "1e61fcd0-65fa-414f-8838-d76f1394b041",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/03008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03008.jpg"
+            "imagesrc": "/images/cards/en/03008.jpg"
         },
         {
             "last-modified": "2015-09-28T20:17:15+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "437cd8a9-fe8a-497f-9625-9054511f91ea",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/03009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03009.jpg"
+            "imagesrc": "/images/cards/en/03009.jpg"
         },
         {
             "last-modified": "2015-01-05T03:24:46+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "6203abc7-7882-4718-a361-33cf1cf90df0",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/03010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03010.jpg"
+            "imagesrc": "/images/cards/en/03010.jpg"
         },
         {
             "last-modified": "2015-01-06T10:31:29+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "3045a35c-8567-40bc-9a59-2fabacd8b3e4",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/03011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03011.jpg"
+            "imagesrc": "/images/cards/en/03011.jpg"
         },
         {
             "last-modified": "2015-09-28T19:55:14+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "cdc1e1d2-d985-400f-ab3c-f91744619eed",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/03012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03012.jpg"
+            "imagesrc": "/images/cards/en/03012.jpg"
         },
         {
             "last-modified": "2015-09-28T19:55:53+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "949e9f9d-bc65-4486-b115-a1d364aaae0d",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/03013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03013.jpg"
+            "imagesrc": "/images/cards/en/03013.jpg"
         },
         {
             "last-modified": "2015-09-28T19:56:54+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "ffed2e8d-67cf-42ab-8a34-110110b59c72",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/03014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03014.jpg"
+            "imagesrc": "/images/cards/en/03014.jpg"
         },
         {
             "last-modified": "2015-09-28T19:57:45+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "dba818f0-4802-474c-91c8-07536e32fb3d",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/03015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03015.jpg"
+            "imagesrc": "/images/cards/en/03015.jpg"
         },
         {
             "last-modified": "2015-09-28T19:58:55+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "f94631b0-20f6-492b-b732-e36b816e523f",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/03016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03016.jpg"
+            "imagesrc": "/images/cards/en/03016.jpg"
         },
         {
             "last-modified": "2015-09-28T19:59:37+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "8272e52f-aa01-403e-9ea4-0408bdcf3fdc",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/03017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03017.jpg"
+            "imagesrc": "/images/cards/en/03017.jpg"
         },
         {
             "last-modified": "2015-09-28T20:00:16+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "f138c8f1-00cc-4ca4-b145-e9c5105dc76a",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/03018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03018.jpg"
+            "imagesrc": "/images/cards/en/03018.jpg"
         },
         {
             "last-modified": "2015-09-28T20:18:53+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "48c8526d-6dee-4ee8-9636-01d3891db8f8",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/03019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03019.jpg"
+            "imagesrc": "/images/cards/en/03019.jpg"
         },
         {
             "last-modified": "2015-10-03T12:05:27+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "f51e5631-7582-492f-8351-e1e808d39d19",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/03020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03020.jpg"
+            "imagesrc": "/images/cards/en/03020.jpg"
         },
         {
             "last-modified": "2015-09-28T20:02:40+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "a23d36e0-8231-49e7-bbc4-4e56c179b045",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/03021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/03021.jpg"
+            "imagesrc": "/images/cards/en/03021.jpg"
         }
     ]
 }

--- a/packs/DDeeds.json
+++ b/packs/DDeeds.json
@@ -39,7 +39,7 @@
             "octgnid": "fb84426c-6b63-4dee-a2df-2d3c7b89c230",
             "value": "",
             "url": "https://dtdb.co/en/card/11001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11001.jpg"
+            "imagesrc": "/images/cards/en/11001.jpg"
         },
         {
             "last-modified": "2015-11-14T18:44:37+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "d47cff43-d675-4410-929c-508475fd7814",
             "value": "",
             "url": "https://dtdb.co/en/card/11002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11002.jpg"
+            "imagesrc": "/images/cards/en/11002.jpg"
         },
         {
             "last-modified": "2015-11-14T18:45:55+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "668fb674-5e1f-4bc9-98ae-ca7120277ea9",
             "value": "",
             "url": "https://dtdb.co/en/card/11003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11003.jpg"
+            "imagesrc": "/images/cards/en/11003.jpg"
         },
         {
             "last-modified": "2015-11-14T18:48:30+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "5c204eb2-3416-4f3e-8822-ac93c5f66978",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/11004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11004.jpg"
+            "imagesrc": "/images/cards/en/11004.jpg"
         },
         {
             "last-modified": "2015-11-14T18:50:17+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "555ee88e-b7a2-41b9-a781-357a9fc53f65",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/11005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11005.jpg"
+            "imagesrc": "/images/cards/en/11005.jpg"
         },
         {
             "last-modified": "2015-11-14T18:52:53+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "934a695a-50c9-4fcc-8434-cb87d6c5e967",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/11006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11006.jpg"
+            "imagesrc": "/images/cards/en/11006.jpg"
         },
         {
             "last-modified": "2015-11-14T18:55:07+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "4c2da757-17a9-43ed-b7cd-c26efcbc0ff7",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/11007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11007.jpg"
+            "imagesrc": "/images/cards/en/11007.jpg"
         },
         {
             "last-modified": "2015-11-14T18:59:31+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "1ee1c912-a6d1-4c74-8fb7-a3430a2cd1c8",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/11008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11008.jpg"
+            "imagesrc": "/images/cards/en/11008.jpg"
         },
         {
             "last-modified": "2015-11-14T19:02:22+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "8cc64eef-41b5-4e60-a68a-e35384d41a7a",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/11009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11009.jpg"
+            "imagesrc": "/images/cards/en/11009.jpg"
         },
         {
             "last-modified": "2015-11-14T19:04:30+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "08c8a178-3613-4b03-a885-5fc205e7e68e",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/11010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11010.jpg"
+            "imagesrc": "/images/cards/en/11010.jpg"
         },
         {
             "last-modified": "2015-11-14T19:05:56+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "654372b0-0c12-4d64-9f78-128adf6d6457",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/11011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11011.jpg"
+            "imagesrc": "/images/cards/en/11011.jpg"
         },
         {
             "last-modified": "2015-11-14T19:07:25+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "0f21f34d-76ba-4a54-b690-fafa160ef170",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/11012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11012.jpg"
+            "imagesrc": "/images/cards/en/11012.jpg"
         },
         {
             "last-modified": "2017-03-25T11:43:08+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "d760b8cd-7d30-4e1b-a4e6-9b7163eedf85",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/11013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11013.jpg"
+            "imagesrc": "/images/cards/en/11013.jpg"
         },
         {
             "last-modified": "2015-11-14T19:14:31+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "381aa2d3-aa99-49a9-8d53-6b09f8f4bceb",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/11014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11014.jpg"
+            "imagesrc": "/images/cards/en/11014.jpg"
         },
         {
             "last-modified": "2015-11-14T19:15:49+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "9c101ef5-5214-4d20-8e45-906f8fcc23b3",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/11015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11015.jpg"
+            "imagesrc": "/images/cards/en/11015.jpg"
         },
         {
             "last-modified": "2015-11-14T19:24:37+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "4bef1feb-f6b5-44ff-8af4-790d121d12e7",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/11016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11016.jpg"
+            "imagesrc": "/images/cards/en/11016.jpg"
         },
         {
             "last-modified": "2017-12-13T13:56:04+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "774ebaf2-a983-414b-acc3-7250bd61b9f2",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/11017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11017.jpg"
+            "imagesrc": "/images/cards/en/11017.jpg"
         },
         {
             "last-modified": "2015-11-14T19:51:48+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "7eb84c0d-be8e-40b5-891c-b1b4c95b55af",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/11018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11018.jpg"
+            "imagesrc": "/images/cards/en/11018.jpg"
         },
         {
             "last-modified": "2015-11-14T19:53:16+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "e258726e-3705-4d0f-ae7a-d37ce2952b82",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/11019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11019.jpg"
+            "imagesrc": "/images/cards/en/11019.jpg"
         },
         {
             "last-modified": "2015-11-14T19:54:59+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "0967a396-2be7-4a61-afe9-a119034266fc",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/11020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11020.jpg"
+            "imagesrc": "/images/cards/en/11020.jpg"
         },
         {
             "last-modified": "2015-11-14T19:58:58+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "79ec0f19-cc3a-4f63-930e-f3dadf2645f7",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/11021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11021.jpg"
+            "imagesrc": "/images/cards/en/11021.jpg"
         },
         {
             "last-modified": "2015-11-14T19:59:06+01:00",
@@ -732,7 +732,7 @@
             "octgnid": "2c8fd25e-ff8b-4129-8a6c-2c6f3590c455",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/11022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11022.jpg"
+            "imagesrc": "/images/cards/en/11022.jpg"
         },
         {
             "last-modified": "2015-11-14T19:58:22+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "2f4ad55c-0be5-422e-bb47-ccb1a6fe21e0",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/11023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/11023.jpg"
+            "imagesrc": "/images/cards/en/11023.jpg"
         }
     ]
 }

--- a/packs/DT2.json
+++ b/packs/DT2.json
@@ -39,7 +39,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24001",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24001.jpg"
+			"imagesrc": "/images/cards/en/24001.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:49:00+01:00",
@@ -72,7 +72,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24002",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24002.jpg"
+			"imagesrc": "/images/cards/en/24002.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:58:45+01:00",
@@ -105,7 +105,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24003",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24003.jpg"
+			"imagesrc": "/images/cards/en/24003.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:58:56+01:00",
@@ -138,7 +138,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24004",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24004.jpg"
+			"imagesrc": "/images/cards/en/24004.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:04+01:00",
@@ -171,7 +171,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24005",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24005.jpg"
+			"imagesrc": "/images/cards/en/24005.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:11+01:00",
@@ -204,7 +204,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24006",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24006.jpg"
+			"imagesrc": "/images/cards/en/24006.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:18+01:00",
@@ -237,7 +237,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24007",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24007.jpg"
+			"imagesrc": "/images/cards/en/24007.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:30+01:00",
@@ -270,7 +270,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24008",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24008.jpg"
+			"imagesrc": "/images/cards/en/24008.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:39+01:00",
@@ -303,7 +303,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24009",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24009.jpg"
+			"imagesrc": "/images/cards/en/24009.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T17:59:52+01:00",
@@ -336,7 +336,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24010",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24010.jpg"
+			"imagesrc": "/images/cards/en/24010.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:02+01:00",
@@ -369,7 +369,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24011",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24011.jpg"
+			"imagesrc": "/images/cards/en/24011.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:11+01:00",
@@ -402,7 +402,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24012",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24012.jpg"
+			"imagesrc": "/images/cards/en/24012.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:19+01:00",
@@ -435,7 +435,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24013",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24013.jpg"
+			"imagesrc": "/images/cards/en/24013.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:26+01:00",
@@ -468,7 +468,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24014",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24014.jpg"
+			"imagesrc": "/images/cards/en/24014.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:34+01:00",
@@ -501,7 +501,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24015",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24015.jpg"
+			"imagesrc": "/images/cards/en/24015.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:41+01:00",
@@ -534,7 +534,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24016",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24016.jpg"
+			"imagesrc": "/images/cards/en/24016.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:48+01:00",
@@ -567,7 +567,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24017",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24017.jpg"
+			"imagesrc": "/images/cards/en/24017.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:00:54+01:00",
@@ -600,7 +600,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24018",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24018.jpg"
+			"imagesrc": "/images/cards/en/24018.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T18:42:54+01:00",
@@ -633,7 +633,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24019",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24019.jpg"
+			"imagesrc": "/images/cards/en/24019.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:07+01:00",
@@ -666,7 +666,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24020",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24020.jpg"
+			"imagesrc": "/images/cards/en/24020.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:16+01:00",
@@ -699,7 +699,7 @@
 			"octgnid": null,
 			"value": "Spades9",
 			"url": "https://dtdb.co/en/card/24021",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24021.jpg"
+			"imagesrc": "/images/cards/en/24021.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:23+01:00",
@@ -732,7 +732,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24022",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24022.jpg"
+			"imagesrc": "/images/cards/en/24022.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:30+01:00",
@@ -765,7 +765,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24023",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24023.jpg"
+			"imagesrc": "/images/cards/en/24023.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:49+01:00",
@@ -798,7 +798,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24024",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24024.jpg"
+			"imagesrc": "/images/cards/en/24024.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:01:55+01:00",
@@ -831,7 +831,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24025",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24025.jpg"
+			"imagesrc": "/images/cards/en/24025.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:02:05+01:00",
@@ -864,7 +864,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24026",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24026.jpg"
+			"imagesrc": "/images/cards/en/24026.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:02:12+01:00",
@@ -897,7 +897,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24027",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24027.jpg"
+			"imagesrc": "/images/cards/en/24027.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:02:21+01:00",
@@ -930,7 +930,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24028",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24028.jpg"
+			"imagesrc": "/images/cards/en/24028.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:04:50+01:00",
@@ -963,7 +963,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24029",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24029.jpg"
+			"imagesrc": "/images/cards/en/24029.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T18:07:07+01:00",
@@ -996,7 +996,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24030",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24030.jpg"
+			"imagesrc": "/images/cards/en/24030.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:28:02+01:00",
@@ -1029,7 +1029,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24031",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24031.jpg"
+			"imagesrc": "/images/cards/en/24031.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:30:12+01:00",
@@ -1062,7 +1062,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24032",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24032.jpg"
+			"imagesrc": "/images/cards/en/24032.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:32:10+01:00",
@@ -1095,7 +1095,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24033",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24033.jpg"
+			"imagesrc": "/images/cards/en/24033.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:42:39+01:00",
@@ -1128,7 +1128,7 @@
 			"octgnid": null,
 			"value": "Spades9",
 			"url": "https://dtdb.co/en/card/24034",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24034.jpg"
+			"imagesrc": "/images/cards/en/24034.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:45:12+01:00",
@@ -1161,7 +1161,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24035",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24035.jpg"
+			"imagesrc": "/images/cards/en/24035.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:48:07+01:00",
@@ -1194,7 +1194,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24036",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24036.jpg"
+			"imagesrc": "/images/cards/en/24036.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:51:27+01:00",
@@ -1227,7 +1227,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24037",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24037.jpg"
+			"imagesrc": "/images/cards/en/24037.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:25:38+01:00",
@@ -1260,7 +1260,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24038",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24038.jpg"
+			"imagesrc": "/images/cards/en/24038.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:56:31+01:00",
@@ -1293,7 +1293,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24039",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24039.jpg"
+			"imagesrc": "/images/cards/en/24039.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T19:58:40+01:00",
@@ -1326,7 +1326,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24040",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24040.jpg"
+			"imagesrc": "/images/cards/en/24040.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:01:04+01:00",
@@ -1359,7 +1359,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24041",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24041.jpg"
+			"imagesrc": "/images/cards/en/24041.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:03:54+01:00",
@@ -1392,7 +1392,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24042",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24042.jpg"
+			"imagesrc": "/images/cards/en/24042.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:06:16+01:00",
@@ -1425,7 +1425,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24043",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24043.jpg"
+			"imagesrc": "/images/cards/en/24043.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:07:50+01:00",
@@ -1458,7 +1458,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24044",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24044.jpg"
+			"imagesrc": "/images/cards/en/24044.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:09:41+01:00",
@@ -1491,7 +1491,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24045",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24045.jpg"
+			"imagesrc": "/images/cards/en/24045.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:12:08+01:00",
@@ -1524,7 +1524,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24046",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24046.jpg"
+			"imagesrc": "/images/cards/en/24046.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:13:42+01:00",
@@ -1557,7 +1557,7 @@
 			"octgnid": null,
 			"value": "Spades9",
 			"url": "https://dtdb.co/en/card/24047",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24047.jpg"
+			"imagesrc": "/images/cards/en/24047.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:17:06+01:00",
@@ -1590,7 +1590,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24048",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24048.jpg"
+			"imagesrc": "/images/cards/en/24048.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:19:03+01:00",
@@ -1623,7 +1623,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24049",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24049.jpg"
+			"imagesrc": "/images/cards/en/24049.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:21:32+01:00",
@@ -1656,7 +1656,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24050",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24050.jpg"
+			"imagesrc": "/images/cards/en/24050.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:25:10+01:00",
@@ -1689,7 +1689,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24051",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24051.jpg"
+			"imagesrc": "/images/cards/en/24051.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:29:15+01:00",
@@ -1722,7 +1722,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24052",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24052.jpg"
+			"imagesrc": "/images/cards/en/24052.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:31:04+01:00",
@@ -1755,7 +1755,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24053",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24053.jpg"
+			"imagesrc": "/images/cards/en/24053.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:32:52+01:00",
@@ -1788,7 +1788,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24054",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24054.jpg"
+			"imagesrc": "/images/cards/en/24054.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:34:53+01:00",
@@ -1821,7 +1821,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24055",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24055.jpg"
+			"imagesrc": "/images/cards/en/24055.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:36:36+01:00",
@@ -1854,7 +1854,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24056",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24056.jpg"
+			"imagesrc": "/images/cards/en/24056.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:38:39+01:00",
@@ -1887,7 +1887,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24057",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24057.jpg"
+			"imagesrc": "/images/cards/en/24057.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:43:21+01:00",
@@ -1920,7 +1920,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24058",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24058.jpg"
+			"imagesrc": "/images/cards/en/24058.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:46:27+01:00",
@@ -1953,7 +1953,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24059",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24059.jpg"
+			"imagesrc": "/images/cards/en/24059.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:49:25+01:00",
@@ -1986,7 +1986,7 @@
 			"octgnid": null,
 			"value": "Spades9",
 			"url": "https://dtdb.co/en/card/24060",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24060.jpg"
+			"imagesrc": "/images/cards/en/24060.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:51:26+01:00",
@@ -2019,7 +2019,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24061",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24061.jpg"
+			"imagesrc": "/images/cards/en/24061.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:57:46+01:00",
@@ -2052,7 +2052,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24062",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24062.jpg"
+			"imagesrc": "/images/cards/en/24062.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T20:59:52+01:00",
@@ -2085,7 +2085,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24063",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24063.jpg"
+			"imagesrc": "/images/cards/en/24063.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:03:13+01:00",
@@ -2118,7 +2118,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24064",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24064.jpg"
+			"imagesrc": "/images/cards/en/24064.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:05:16+01:00",
@@ -2151,7 +2151,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24065",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24065.jpg"
+			"imagesrc": "/images/cards/en/24065.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:07:05+01:00",
@@ -2184,7 +2184,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24066",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24066.jpg"
+			"imagesrc": "/images/cards/en/24066.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:10:31+01:00",
@@ -2217,7 +2217,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24067",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24067.jpg"
+			"imagesrc": "/images/cards/en/24067.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:13:02+01:00",
@@ -2250,7 +2250,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24068",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24068.jpg"
+			"imagesrc": "/images/cards/en/24068.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:15:20+01:00",
@@ -2283,7 +2283,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24069",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24069.jpg"
+			"imagesrc": "/images/cards/en/24069.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:17:24+01:00",
@@ -2316,7 +2316,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24070",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24070.jpg"
+			"imagesrc": "/images/cards/en/24070.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:20:47+01:00",
@@ -2349,7 +2349,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24071",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24071.jpg"
+			"imagesrc": "/images/cards/en/24071.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:23:09+01:00",
@@ -2382,7 +2382,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24072",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24072.jpg"
+			"imagesrc": "/images/cards/en/24072.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T18:26:52+01:00",
@@ -2415,7 +2415,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24073",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24073.jpg"
+			"imagesrc": "/images/cards/en/24073.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:46:34+01:00",
@@ -2448,7 +2448,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24074",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24074.jpg"
+			"imagesrc": "/images/cards/en/24074.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T18:15:42+01:00",
@@ -2481,7 +2481,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24075",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24075.jpg"
+			"imagesrc": "/images/cards/en/24075.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:35:05+01:00",
@@ -2514,7 +2514,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24076",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24076.jpg"
+			"imagesrc": "/images/cards/en/24076.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:49:21+01:00",
@@ -2547,7 +2547,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24077",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24077.jpg"
+			"imagesrc": "/images/cards/en/24077.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:42:11+01:00",
@@ -2580,7 +2580,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24078",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24078.jpg"
+			"imagesrc": "/images/cards/en/24078.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:44:27+01:00",
@@ -2613,7 +2613,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24079",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24079.jpg"
+			"imagesrc": "/images/cards/en/24079.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:46:23+01:00",
@@ -2646,7 +2646,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24080",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24080.jpg"
+			"imagesrc": "/images/cards/en/24080.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:48:20+01:00",
@@ -2679,7 +2679,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24081",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24081.jpg"
+			"imagesrc": "/images/cards/en/24081.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T21:50:42+01:00",
@@ -2712,7 +2712,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24082",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24082.jpg"
+			"imagesrc": "/images/cards/en/24082.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:09:37+01:00",
@@ -2745,7 +2745,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24083",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24083.jpg"
+			"imagesrc": "/images/cards/en/24083.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:13:55+01:00",
@@ -2778,7 +2778,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24084",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24084.jpg"
+			"imagesrc": "/images/cards/en/24084.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:20:12+01:00",
@@ -2811,7 +2811,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24085",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24085.jpg"
+			"imagesrc": "/images/cards/en/24085.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:52:50+01:00",
@@ -2844,7 +2844,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24086",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24086.jpg"
+			"imagesrc": "/images/cards/en/24086.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:24:22+01:00",
@@ -2877,7 +2877,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24087",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24087.jpg"
+			"imagesrc": "/images/cards/en/24087.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:27:00+01:00",
@@ -2910,7 +2910,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24088",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24088.jpg"
+			"imagesrc": "/images/cards/en/24088.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:30:57+01:00",
@@ -2943,7 +2943,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24089",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24089.jpg"
+			"imagesrc": "/images/cards/en/24089.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:55:00+01:00",
@@ -2976,7 +2976,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24090",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24090.jpg"
+			"imagesrc": "/images/cards/en/24090.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:36:14+01:00",
@@ -3009,7 +3009,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24091",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24091.jpg"
+			"imagesrc": "/images/cards/en/24091.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:38:07+01:00",
@@ -3042,7 +3042,7 @@
 			"octgnid": null,
 			"value": "Spades2",
 			"url": "https://dtdb.co/en/card/24092",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24092.jpg"
+			"imagesrc": "/images/cards/en/24092.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:41:01+01:00",
@@ -3075,7 +3075,7 @@
 			"octgnid": null,
 			"value": "Spades3",
 			"url": "https://dtdb.co/en/card/24093",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24093.jpg"
+			"imagesrc": "/images/cards/en/24093.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:43:05+01:00",
@@ -3108,7 +3108,7 @@
 			"octgnid": null,
 			"value": "Spades4",
 			"url": "https://dtdb.co/en/card/24094",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24094.jpg"
+			"imagesrc": "/images/cards/en/24094.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:44:53+01:00",
@@ -3141,7 +3141,7 @@
 			"octgnid": null,
 			"value": "Spades5",
 			"url": "https://dtdb.co/en/card/24095",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24095.jpg"
+			"imagesrc": "/images/cards/en/24095.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:47:28+01:00",
@@ -3174,7 +3174,7 @@
 			"octgnid": null,
 			"value": "Spades6",
 			"url": "https://dtdb.co/en/card/24096",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24096.jpg"
+			"imagesrc": "/images/cards/en/24096.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:49:39+01:00",
@@ -3207,7 +3207,7 @@
 			"octgnid": null,
 			"value": "Spades7",
 			"url": "https://dtdb.co/en/card/24097",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24097.jpg"
+			"imagesrc": "/images/cards/en/24097.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:57:56+01:00",
@@ -3240,7 +3240,7 @@
 			"octgnid": null,
 			"value": "Spades8",
 			"url": "https://dtdb.co/en/card/24098",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24098.jpg"
+			"imagesrc": "/images/cards/en/24098.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:53:31+01:00",
@@ -3273,7 +3273,7 @@
 			"octgnid": null,
 			"value": "Spades9",
 			"url": "https://dtdb.co/en/card/24099",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24099.jpg"
+			"imagesrc": "/images/cards/en/24099.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:55:13+01:00",
@@ -3306,7 +3306,7 @@
 			"octgnid": null,
 			"value": "Spades10",
 			"url": "https://dtdb.co/en/card/24100",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24100.jpg"
+			"imagesrc": "/images/cards/en/24100.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:56:25+01:00",
@@ -3339,7 +3339,7 @@
 			"octgnid": null,
 			"value": "Spades11",
 			"url": "https://dtdb.co/en/card/24101",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24101.jpg"
+			"imagesrc": "/images/cards/en/24101.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:58:15+01:00",
@@ -3372,7 +3372,7 @@
 			"octgnid": null,
 			"value": "Spades12",
 			"url": "https://dtdb.co/en/card/24102",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24102.jpg"
+			"imagesrc": "/images/cards/en/24102.jpg"
 		},
 		{
 			"last-modified": "2021-12-26T22:59:57+01:00",
@@ -3405,7 +3405,7 @@
 			"octgnid": null,
 			"value": "Spades13",
 			"url": "https://dtdb.co/en/card/24103",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24103.jpg"
+			"imagesrc": "/images/cards/en/24103.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:48:05+01:00",
@@ -3438,7 +3438,7 @@
 			"octgnid": null,
 			"value": "Diams1",
 			"url": "https://dtdb.co/en/card/24104",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24104.jpg"
+			"imagesrc": "/images/cards/en/24104.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:49:53+01:00",
@@ -3471,7 +3471,7 @@
 			"octgnid": null,
 			"value": "Diams1",
 			"url": "https://dtdb.co/en/card/24105",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24105.jpg"
+			"imagesrc": "/images/cards/en/24105.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:52:16+01:00",
@@ -3504,7 +3504,7 @@
 			"octgnid": null,
 			"value": "Diams1",
 			"url": "https://dtdb.co/en/card/24106",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24106.jpg"
+			"imagesrc": "/images/cards/en/24106.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:53:59+01:00",
@@ -3537,7 +3537,7 @@
 			"octgnid": null,
 			"value": "Diams2",
 			"url": "https://dtdb.co/en/card/24107",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24107.jpg"
+			"imagesrc": "/images/cards/en/24107.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:56:37+01:00",
@@ -3570,7 +3570,7 @@
 			"octgnid": null,
 			"value": "Diams2",
 			"url": "https://dtdb.co/en/card/24108",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24108.jpg"
+			"imagesrc": "/images/cards/en/24108.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:57:52+01:00",
@@ -3603,7 +3603,7 @@
 			"octgnid": null,
 			"value": "Diams2",
 			"url": "https://dtdb.co/en/card/24109",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24109.jpg"
+			"imagesrc": "/images/cards/en/24109.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T17:59:08+01:00",
@@ -3636,7 +3636,7 @@
 			"octgnid": null,
 			"value": "Diams3",
 			"url": "https://dtdb.co/en/card/24110",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24110.jpg"
+			"imagesrc": "/images/cards/en/24110.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T18:00:47+01:00",
@@ -3669,7 +3669,7 @@
 			"octgnid": null,
 			"value": "Diams3",
 			"url": "https://dtdb.co/en/card/24111",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24111.jpg"
+			"imagesrc": "/images/cards/en/24111.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T18:02:21+01:00",
@@ -3702,7 +3702,7 @@
 			"octgnid": null,
 			"value": "Diams3",
 			"url": "https://dtdb.co/en/card/24112",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24112.jpg"
+			"imagesrc": "/images/cards/en/24112.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T18:15:18+01:00",
@@ -3735,7 +3735,7 @@
 			"octgnid": null,
 			"value": "Diams4",
 			"url": "https://dtdb.co/en/card/24113",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24113.jpg"
+			"imagesrc": "/images/cards/en/24113.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T18:18:25+01:00",
@@ -3768,7 +3768,7 @@
 			"octgnid": null,
 			"value": "Diams4",
 			"url": "https://dtdb.co/en/card/24114",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24114.jpg"
+			"imagesrc": "/images/cards/en/24114.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:05:18+01:00",
@@ -3801,7 +3801,7 @@
 			"octgnid": null,
 			"value": "Diams4",
 			"url": "https://dtdb.co/en/card/24115",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24115.jpg"
+			"imagesrc": "/images/cards/en/24115.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:07:11+01:00",
@@ -3834,7 +3834,7 @@
 			"octgnid": null,
 			"value": "Diams5",
 			"url": "https://dtdb.co/en/card/24116",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24116.jpg"
+			"imagesrc": "/images/cards/en/24116.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:09:42+01:00",
@@ -3867,7 +3867,7 @@
 			"octgnid": null,
 			"value": "Diams5",
 			"url": "https://dtdb.co/en/card/24117",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24117.jpg"
+			"imagesrc": "/images/cards/en/24117.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:11:15+01:00",
@@ -3900,7 +3900,7 @@
 			"octgnid": null,
 			"value": "Diams5",
 			"url": "https://dtdb.co/en/card/24118",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24118.jpg"
+			"imagesrc": "/images/cards/en/24118.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:13:45+01:00",
@@ -3933,7 +3933,7 @@
 			"octgnid": null,
 			"value": "Diams6",
 			"url": "https://dtdb.co/en/card/24119",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24119.jpg"
+			"imagesrc": "/images/cards/en/24119.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:17:22+01:00",
@@ -3966,7 +3966,7 @@
 			"octgnid": null,
 			"value": "Diams6",
 			"url": "https://dtdb.co/en/card/24120",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24120.jpg"
+			"imagesrc": "/images/cards/en/24120.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:19:12+01:00",
@@ -3999,7 +3999,7 @@
 			"octgnid": null,
 			"value": "Diams6",
 			"url": "https://dtdb.co/en/card/24121",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24121.jpg"
+			"imagesrc": "/images/cards/en/24121.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:20:49+01:00",
@@ -4032,7 +4032,7 @@
 			"octgnid": null,
 			"value": "Diams7",
 			"url": "https://dtdb.co/en/card/24122",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24122.jpg"
+			"imagesrc": "/images/cards/en/24122.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:22:53+01:00",
@@ -4065,7 +4065,7 @@
 			"octgnid": null,
 			"value": "Diams7",
 			"url": "https://dtdb.co/en/card/24123",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24123.jpg"
+			"imagesrc": "/images/cards/en/24123.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:24:33+01:00",
@@ -4098,7 +4098,7 @@
 			"octgnid": null,
 			"value": "Diams7",
 			"url": "https://dtdb.co/en/card/24124",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24124.jpg"
+			"imagesrc": "/images/cards/en/24124.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:26:14+01:00",
@@ -4131,7 +4131,7 @@
 			"octgnid": null,
 			"value": "Diams8",
 			"url": "https://dtdb.co/en/card/24125",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24125.jpg"
+			"imagesrc": "/images/cards/en/24125.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:28:08+01:00",
@@ -4164,7 +4164,7 @@
 			"octgnid": null,
 			"value": "Diams8",
 			"url": "https://dtdb.co/en/card/24126",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24126.jpg"
+			"imagesrc": "/images/cards/en/24126.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:29:43+01:00",
@@ -4197,7 +4197,7 @@
 			"octgnid": null,
 			"value": "Diams8",
 			"url": "https://dtdb.co/en/card/24127",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24127.jpg"
+			"imagesrc": "/images/cards/en/24127.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:31:36+01:00",
@@ -4230,7 +4230,7 @@
 			"octgnid": null,
 			"value": "Diams9",
 			"url": "https://dtdb.co/en/card/24128",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24128.jpg"
+			"imagesrc": "/images/cards/en/24128.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:33:47+01:00",
@@ -4263,7 +4263,7 @@
 			"octgnid": null,
 			"value": "Diams9",
 			"url": "https://dtdb.co/en/card/24129",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24129.jpg"
+			"imagesrc": "/images/cards/en/24129.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:35:02+01:00",
@@ -4296,7 +4296,7 @@
 			"octgnid": null,
 			"value": "Diams9",
 			"url": "https://dtdb.co/en/card/24130",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24130.jpg"
+			"imagesrc": "/images/cards/en/24130.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:36:38+01:00",
@@ -4329,7 +4329,7 @@
 			"octgnid": null,
 			"value": "Diams10",
 			"url": "https://dtdb.co/en/card/24131",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24131.jpg"
+			"imagesrc": "/images/cards/en/24131.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:40:40+01:00",
@@ -4362,7 +4362,7 @@
 			"octgnid": null,
 			"value": "Diams10",
 			"url": "https://dtdb.co/en/card/24132",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24132.jpg"
+			"imagesrc": "/images/cards/en/24132.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:42:13+01:00",
@@ -4395,7 +4395,7 @@
 			"octgnid": null,
 			"value": "Diams10",
 			"url": "https://dtdb.co/en/card/24133",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24133.jpg"
+			"imagesrc": "/images/cards/en/24133.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:43:50+01:00",
@@ -4428,7 +4428,7 @@
 			"octgnid": null,
 			"value": "Diams11",
 			"url": "https://dtdb.co/en/card/24134",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24134.jpg"
+			"imagesrc": "/images/cards/en/24134.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:45:39+01:00",
@@ -4461,7 +4461,7 @@
 			"octgnid": null,
 			"value": "Diams11",
 			"url": "https://dtdb.co/en/card/24135",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24135.jpg"
+			"imagesrc": "/images/cards/en/24135.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T23:18:16+01:00",
@@ -4494,7 +4494,7 @@
 			"octgnid": null,
 			"value": "Diams11",
 			"url": "https://dtdb.co/en/card/24136",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24136.jpg"
+			"imagesrc": "/images/cards/en/24136.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:55:04+01:00",
@@ -4527,7 +4527,7 @@
 			"octgnid": null,
 			"value": "Diams12",
 			"url": "https://dtdb.co/en/card/24137",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24137.jpg"
+			"imagesrc": "/images/cards/en/24137.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:56:34+01:00",
@@ -4560,7 +4560,7 @@
 			"octgnid": null,
 			"value": "Diams12",
 			"url": "https://dtdb.co/en/card/24138",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24138.jpg"
+			"imagesrc": "/images/cards/en/24138.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:57:57+01:00",
@@ -4593,7 +4593,7 @@
 			"octgnid": null,
 			"value": "Diams12",
 			"url": "https://dtdb.co/en/card/24139",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24139.jpg"
+			"imagesrc": "/images/cards/en/24139.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T16:59:38+01:00",
@@ -4626,7 +4626,7 @@
 			"octgnid": null,
 			"value": "Diams13",
 			"url": "https://dtdb.co/en/card/24140",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24140.jpg"
+			"imagesrc": "/images/cards/en/24140.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:01:12+01:00",
@@ -4659,7 +4659,7 @@
 			"octgnid": null,
 			"value": "Diams13",
 			"url": "https://dtdb.co/en/card/24141",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24141.jpg"
+			"imagesrc": "/images/cards/en/24141.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:02:56+01:00",
@@ -4692,7 +4692,7 @@
 			"octgnid": null,
 			"value": "Diams13",
 			"url": "https://dtdb.co/en/card/24142",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24142.jpg"
+			"imagesrc": "/images/cards/en/24142.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:08:14+01:00",
@@ -4725,7 +4725,7 @@
 			"octgnid": null,
 			"value": "Hearts1",
 			"url": "https://dtdb.co/en/card/24143",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24143.jpg"
+			"imagesrc": "/images/cards/en/24143.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T23:20:29+01:00",
@@ -4758,7 +4758,7 @@
 			"octgnid": null,
 			"value": "Hearts1",
 			"url": "https://dtdb.co/en/card/24144",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24144.jpg"
+			"imagesrc": "/images/cards/en/24144.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:10:33+01:00",
@@ -4791,7 +4791,7 @@
 			"octgnid": null,
 			"value": "Hearts1",
 			"url": "https://dtdb.co/en/card/24145",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24145.jpg"
+			"imagesrc": "/images/cards/en/24145.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:13:30+01:00",
@@ -4824,7 +4824,7 @@
 			"octgnid": null,
 			"value": "Hearts2",
 			"url": "https://dtdb.co/en/card/24146",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24146.jpg"
+			"imagesrc": "/images/cards/en/24146.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:24:04+01:00",
@@ -4857,7 +4857,7 @@
 			"octgnid": null,
 			"value": "Hearts2",
 			"url": "https://dtdb.co/en/card/24147",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24147.jpg"
+			"imagesrc": "/images/cards/en/24147.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:26:28+01:00",
@@ -4890,7 +4890,7 @@
 			"octgnid": null,
 			"value": "Hearts2",
 			"url": "https://dtdb.co/en/card/24148",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24148.jpg"
+			"imagesrc": "/images/cards/en/24148.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:29:26+01:00",
@@ -4923,7 +4923,7 @@
 			"octgnid": null,
 			"value": "Hearts3",
 			"url": "https://dtdb.co/en/card/24149",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24149.jpg"
+			"imagesrc": "/images/cards/en/24149.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T23:47:24+01:00",
@@ -4956,7 +4956,7 @@
 			"octgnid": null,
 			"value": "Hearts3",
 			"url": "https://dtdb.co/en/card/24150",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24150.jpg"
+			"imagesrc": "/images/cards/en/24150.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:32:34+01:00",
@@ -4989,7 +4989,7 @@
 			"octgnid": null,
 			"value": "Hearts3",
 			"url": "https://dtdb.co/en/card/24151",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24151.jpg"
+			"imagesrc": "/images/cards/en/24151.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:34:23+01:00",
@@ -5022,7 +5022,7 @@
 			"octgnid": null,
 			"value": "Hearts4",
 			"url": "https://dtdb.co/en/card/24152",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24152.jpg"
+			"imagesrc": "/images/cards/en/24152.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:35:42+01:00",
@@ -5055,7 +5055,7 @@
 			"octgnid": null,
 			"value": "Hearts4",
 			"url": "https://dtdb.co/en/card/24153",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24153.jpg"
+			"imagesrc": "/images/cards/en/24153.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:36:54+01:00",
@@ -5088,7 +5088,7 @@
 			"octgnid": null,
 			"value": "Hearts4",
 			"url": "https://dtdb.co/en/card/24154",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24154.jpg"
+			"imagesrc": "/images/cards/en/24154.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:38:19+01:00",
@@ -5121,7 +5121,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24155",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24155.jpg"
+			"imagesrc": "/images/cards/en/24155.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:40:10+01:00",
@@ -5154,7 +5154,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24156",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24156.jpg"
+			"imagesrc": "/images/cards/en/24156.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:42:44+01:00",
@@ -5187,7 +5187,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24157",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24157.jpg"
+			"imagesrc": "/images/cards/en/24157.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:44:47+01:00",
@@ -5220,7 +5220,7 @@
 			"octgnid": null,
 			"value": "Hearts6",
 			"url": "https://dtdb.co/en/card/24158",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24158.jpg"
+			"imagesrc": "/images/cards/en/24158.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T17:47:14+01:00",
@@ -5253,7 +5253,7 @@
 			"octgnid": null,
 			"value": "Hearts6",
 			"url": "https://dtdb.co/en/card/24159",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24159.jpg"
+			"imagesrc": "/images/cards/en/24159.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T00:46:02+01:00",
@@ -5286,7 +5286,7 @@
 			"octgnid": null,
 			"value": "Hearts6",
 			"url": "https://dtdb.co/en/card/24160",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24160.jpg"
+			"imagesrc": "/images/cards/en/24160.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T00:48:30+01:00",
@@ -5319,7 +5319,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24161",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24161.jpg"
+			"imagesrc": "/images/cards/en/24161.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T00:52:45+01:00",
@@ -5352,7 +5352,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24162",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24162.jpg"
+			"imagesrc": "/images/cards/en/24162.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T00:54:26+01:00",
@@ -5385,7 +5385,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24163",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24163.jpg"
+			"imagesrc": "/images/cards/en/24163.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T00:58:55+01:00",
@@ -5418,7 +5418,7 @@
 			"octgnid": null,
 			"value": "Hearts8",
 			"url": "https://dtdb.co/en/card/24164",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24164.jpg"
+			"imagesrc": "/images/cards/en/24164.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:00:34+01:00",
@@ -5451,7 +5451,7 @@
 			"octgnid": null,
 			"value": "Hearts8",
 			"url": "https://dtdb.co/en/card/24165",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24165.jpg"
+			"imagesrc": "/images/cards/en/24165.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:03:55+01:00",
@@ -5484,7 +5484,7 @@
 			"octgnid": null,
 			"value": "Hearts8",
 			"url": "https://dtdb.co/en/card/24166",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24166.jpg"
+			"imagesrc": "/images/cards/en/24166.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:06:25+01:00",
@@ -5517,7 +5517,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24167",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24167.jpg"
+			"imagesrc": "/images/cards/en/24167.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:15:31+01:00",
@@ -5550,7 +5550,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24168",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24168.jpg"
+			"imagesrc": "/images/cards/en/24168.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:17:09+01:00",
@@ -5583,7 +5583,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24169",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24169.jpg"
+			"imagesrc": "/images/cards/en/24169.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:18:51+01:00",
@@ -5616,7 +5616,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24170",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24170.jpg"
+			"imagesrc": "/images/cards/en/24170.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:20:43+01:00",
@@ -5649,7 +5649,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24171",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24171.jpg"
+			"imagesrc": "/images/cards/en/24171.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:22:14+01:00",
@@ -5682,7 +5682,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24172",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24172.jpg"
+			"imagesrc": "/images/cards/en/24172.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T01:23:44+01:00",
@@ -5715,7 +5715,7 @@
 			"octgnid": null,
 			"value": "Hearts11",
 			"url": "https://dtdb.co/en/card/24173",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24173.jpg"
+			"imagesrc": "/images/cards/en/24173.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:16:06+01:00",
@@ -5748,7 +5748,7 @@
 			"octgnid": null,
 			"value": "Hearts11",
 			"url": "https://dtdb.co/en/card/24174",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24174.jpg"
+			"imagesrc": "/images/cards/en/24174.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:18:27+01:00",
@@ -5781,7 +5781,7 @@
 			"octgnid": null,
 			"value": "Hearts11",
 			"url": "https://dtdb.co/en/card/24175",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24175.jpg"
+			"imagesrc": "/images/cards/en/24175.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:21:09+01:00",
@@ -5814,7 +5814,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24176",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24176.jpg"
+			"imagesrc": "/images/cards/en/24176.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:28:00+01:00",
@@ -5847,7 +5847,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24177",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24177.jpg"
+			"imagesrc": "/images/cards/en/24177.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:29:48+01:00",
@@ -5880,7 +5880,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24178",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24178.jpg"
+			"imagesrc": "/images/cards/en/24178.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:30:51+01:00",
@@ -5913,7 +5913,7 @@
 			"octgnid": null,
 			"value": "Hearts13",
 			"url": "https://dtdb.co/en/card/24179",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24179.jpg"
+			"imagesrc": "/images/cards/en/24179.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:32:41+01:00",
@@ -5946,7 +5946,7 @@
 			"octgnid": null,
 			"value": "Hearts13",
 			"url": "https://dtdb.co/en/card/24180",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24180.jpg"
+			"imagesrc": "/images/cards/en/24180.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:34:13+01:00",
@@ -5979,7 +5979,7 @@
 			"octgnid": null,
 			"value": "Hearts1",
 			"url": "https://dtdb.co/en/card/24181",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24181.jpg"
+			"imagesrc": "/images/cards/en/24181.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:35:28+01:00",
@@ -6012,7 +6012,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24182",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24182.jpg"
+			"imagesrc": "/images/cards/en/24182.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:37:20+01:00",
@@ -6045,7 +6045,7 @@
 			"octgnid": null,
 			"value": "Hearts6",
 			"url": "https://dtdb.co/en/card/24183",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24183.jpg"
+			"imagesrc": "/images/cards/en/24183.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:38:35+01:00",
@@ -6078,7 +6078,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24184",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24184.jpg"
+			"imagesrc": "/images/cards/en/24184.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:39:57+01:00",
@@ -6111,7 +6111,7 @@
 			"octgnid": null,
 			"value": "Hearts8",
 			"url": "https://dtdb.co/en/card/24185",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24185.jpg"
+			"imagesrc": "/images/cards/en/24185.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:41:32+01:00",
@@ -6144,7 +6144,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24186",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24186.jpg"
+			"imagesrc": "/images/cards/en/24186.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:42:58+01:00",
@@ -6177,7 +6177,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24187",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24187.jpg"
+			"imagesrc": "/images/cards/en/24187.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:44:15+01:00",
@@ -6210,7 +6210,7 @@
 			"octgnid": null,
 			"value": "Hearts11",
 			"url": "https://dtdb.co/en/card/24188",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24188.jpg"
+			"imagesrc": "/images/cards/en/24188.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:45:48+01:00",
@@ -6243,7 +6243,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24189",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24189.jpg"
+			"imagesrc": "/images/cards/en/24189.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:47:27+01:00",
@@ -6276,7 +6276,7 @@
 			"octgnid": null,
 			"value": "Hearts13",
 			"url": "https://dtdb.co/en/card/24190",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24190.jpg"
+			"imagesrc": "/images/cards/en/24190.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:50:14+01:00",
@@ -6309,7 +6309,7 @@
 			"octgnid": null,
 			"value": "Hearts2",
 			"url": "https://dtdb.co/en/card/24191",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24191.jpg"
+			"imagesrc": "/images/cards/en/24191.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:52:27+01:00",
@@ -6342,7 +6342,7 @@
 			"octgnid": null,
 			"value": "Hearts3",
 			"url": "https://dtdb.co/en/card/24192",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24192.jpg"
+			"imagesrc": "/images/cards/en/24192.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:53:57+01:00",
@@ -6375,7 +6375,7 @@
 			"octgnid": null,
 			"value": "Hearts4",
 			"url": "https://dtdb.co/en/card/24193",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24193.jpg"
+			"imagesrc": "/images/cards/en/24193.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:55:44+01:00",
@@ -6408,7 +6408,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24194",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24194.jpg"
+			"imagesrc": "/images/cards/en/24194.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:57:14+01:00",
@@ -6441,7 +6441,7 @@
 			"octgnid": null,
 			"value": "Hearts6",
 			"url": "https://dtdb.co/en/card/24195",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24195.jpg"
+			"imagesrc": "/images/cards/en/24195.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T02:59:16+01:00",
@@ -6474,7 +6474,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24196",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24196.jpg"
+			"imagesrc": "/images/cards/en/24196.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:01:10+01:00",
@@ -6507,7 +6507,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24197",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24197.jpg"
+			"imagesrc": "/images/cards/en/24197.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:03:04+01:00",
@@ -6540,7 +6540,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24198",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24198.jpg"
+			"imagesrc": "/images/cards/en/24198.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:04:31+01:00",
@@ -6573,7 +6573,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24199",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24199.jpg"
+			"imagesrc": "/images/cards/en/24199.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:06:19+01:00",
@@ -6606,7 +6606,7 @@
 			"octgnid": null,
 			"value": "Hearts13",
 			"url": "https://dtdb.co/en/card/24200",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24200.jpg"
+			"imagesrc": "/images/cards/en/24200.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:07:47+01:00",
@@ -6639,7 +6639,7 @@
 			"octgnid": null,
 			"value": "Hearts1",
 			"url": "https://dtdb.co/en/card/24201",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24201.jpg"
+			"imagesrc": "/images/cards/en/24201.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:09:52+01:00",
@@ -6672,7 +6672,7 @@
 			"octgnid": null,
 			"value": "Hearts4",
 			"url": "https://dtdb.co/en/card/24202",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24202.jpg"
+			"imagesrc": "/images/cards/en/24202.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:11:43+01:00",
@@ -6705,7 +6705,7 @@
 			"octgnid": null,
 			"value": "Hearts5",
 			"url": "https://dtdb.co/en/card/24203",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24203.jpg"
+			"imagesrc": "/images/cards/en/24203.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:18:15+01:00",
@@ -6738,7 +6738,7 @@
 			"octgnid": null,
 			"value": "Hearts7",
 			"url": "https://dtdb.co/en/card/24204",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24204.jpg"
+			"imagesrc": "/images/cards/en/24204.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:31:44+01:00",
@@ -6771,7 +6771,7 @@
 			"octgnid": null,
 			"value": "Hearts8",
 			"url": "https://dtdb.co/en/card/24205",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24205.jpg"
+			"imagesrc": "/images/cards/en/24205.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:50:28+01:00",
@@ -6804,7 +6804,7 @@
 			"octgnid": null,
 			"value": "Hearts9",
 			"url": "https://dtdb.co/en/card/24206",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24206.jpg"
+			"imagesrc": "/images/cards/en/24206.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:52:27+01:00",
@@ -6837,7 +6837,7 @@
 			"octgnid": null,
 			"value": "Hearts10",
 			"url": "https://dtdb.co/en/card/24207",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24207.jpg"
+			"imagesrc": "/images/cards/en/24207.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:54:47+01:00",
@@ -6870,7 +6870,7 @@
 			"octgnid": null,
 			"value": "Hearts11",
 			"url": "https://dtdb.co/en/card/24208",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24208.jpg"
+			"imagesrc": "/images/cards/en/24208.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T03:57:33+01:00",
@@ -6903,7 +6903,7 @@
 			"octgnid": null,
 			"value": "Hearts12",
 			"url": "https://dtdb.co/en/card/24209",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24209.jpg"
+			"imagesrc": "/images/cards/en/24209.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T04:00:16+01:00",
@@ -6936,7 +6936,7 @@
 			"octgnid": null,
 			"value": "Hearts13",
 			"url": "https://dtdb.co/en/card/24210",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24210.jpg"
+			"imagesrc": "/images/cards/en/24210.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:57:37+01:00",
@@ -6969,7 +6969,7 @@
 			"octgnid": null,
 			"value": "Clubs1",
 			"url": "https://dtdb.co/en/card/24211",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24211.jpg"
+			"imagesrc": "/images/cards/en/24211.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:55:02+01:00",
@@ -7002,7 +7002,7 @@
 			"octgnid": null,
 			"value": "Clubs1",
 			"url": "https://dtdb.co/en/card/24212",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24212.jpg"
+			"imagesrc": "/images/cards/en/24212.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:52:38+01:00",
@@ -7035,7 +7035,7 @@
 			"octgnid": null,
 			"value": "Clubs1",
 			"url": "https://dtdb.co/en/card/24213",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24213.jpg"
+			"imagesrc": "/images/cards/en/24213.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:49:15+01:00",
@@ -7068,7 +7068,7 @@
 			"octgnid": null,
 			"value": "Clubs2",
 			"url": "https://dtdb.co/en/card/24214",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24214.jpg"
+			"imagesrc": "/images/cards/en/24214.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:40:05+01:00",
@@ -7101,7 +7101,7 @@
 			"octgnid": null,
 			"value": "Clubs2",
 			"url": "https://dtdb.co/en/card/24215",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24215.jpg"
+			"imagesrc": "/images/cards/en/24215.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:35:58+01:00",
@@ -7134,7 +7134,7 @@
 			"octgnid": null,
 			"value": "Clubs2",
 			"url": "https://dtdb.co/en/card/24216",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24216.jpg"
+			"imagesrc": "/images/cards/en/24216.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:34:04+01:00",
@@ -7167,7 +7167,7 @@
 			"octgnid": null,
 			"value": "Clubs2",
 			"url": "https://dtdb.co/en/card/24217",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24217.jpg"
+			"imagesrc": "/images/cards/en/24217.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:31:58+01:00",
@@ -7200,7 +7200,7 @@
 			"octgnid": null,
 			"value": "Clubs3",
 			"url": "https://dtdb.co/en/card/24218",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24218.jpg"
+			"imagesrc": "/images/cards/en/24218.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:25:52+01:00",
@@ -7233,7 +7233,7 @@
 			"octgnid": null,
 			"value": "Clubs3",
 			"url": "https://dtdb.co/en/card/24219",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24219.jpg"
+			"imagesrc": "/images/cards/en/24219.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:23:47+01:00",
@@ -7266,7 +7266,7 @@
 			"octgnid": null,
 			"value": "Clubs3",
 			"url": "https://dtdb.co/en/card/24220",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24220.jpg"
+			"imagesrc": "/images/cards/en/24220.jpg"
 		},
 		{
 			"last-modified": "2021-12-29T16:34:18+01:00",
@@ -7299,7 +7299,7 @@
 			"octgnid": null,
 			"value": "Clubs3",
 			"url": "https://dtdb.co/en/card/24221",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24221.jpg"
+			"imagesrc": "/images/cards/en/24221.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:18:13+01:00",
@@ -7332,7 +7332,7 @@
 			"octgnid": null,
 			"value": "Clubs4",
 			"url": "https://dtdb.co/en/card/24222",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24222.jpg"
+			"imagesrc": "/images/cards/en/24222.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:15:11+01:00",
@@ -7365,7 +7365,7 @@
 			"octgnid": null,
 			"value": "Clubs4",
 			"url": "https://dtdb.co/en/card/24223",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24223.jpg"
+			"imagesrc": "/images/cards/en/24223.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:12:32+01:00",
@@ -7398,7 +7398,7 @@
 			"octgnid": null,
 			"value": "Clubs4",
 			"url": "https://dtdb.co/en/card/24224",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24224.jpg"
+			"imagesrc": "/images/cards/en/24224.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:09:40+01:00",
@@ -7431,7 +7431,7 @@
 			"octgnid": null,
 			"value": "Clubs4",
 			"url": "https://dtdb.co/en/card/24225",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24225.jpg"
+			"imagesrc": "/images/cards/en/24225.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:06:52+01:00",
@@ -7464,7 +7464,7 @@
 			"octgnid": null,
 			"value": "Clubs5",
 			"url": "https://dtdb.co/en/card/24226",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24226.jpg"
+			"imagesrc": "/images/cards/en/24226.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:00:34+01:00",
@@ -7497,7 +7497,7 @@
 			"octgnid": null,
 			"value": "Clubs5",
 			"url": "https://dtdb.co/en/card/24227",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24227.jpg"
+			"imagesrc": "/images/cards/en/24227.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:57:43+01:00",
@@ -7530,7 +7530,7 @@
 			"octgnid": null,
 			"value": "Clubs5",
 			"url": "https://dtdb.co/en/card/24228",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24228.jpg"
+			"imagesrc": "/images/cards/en/24228.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:55:32+01:00",
@@ -7563,7 +7563,7 @@
 			"octgnid": null,
 			"value": "Clubs5",
 			"url": "https://dtdb.co/en/card/24229",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24229.jpg"
+			"imagesrc": "/images/cards/en/24229.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:52:11+01:00",
@@ -7596,7 +7596,7 @@
 			"octgnid": null,
 			"value": "Clubs6",
 			"url": "https://dtdb.co/en/card/24230",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24230.jpg"
+			"imagesrc": "/images/cards/en/24230.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:49:56+01:00",
@@ -7629,7 +7629,7 @@
 			"octgnid": null,
 			"value": "Clubs6",
 			"url": "https://dtdb.co/en/card/24231",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24231.jpg"
+			"imagesrc": "/images/cards/en/24231.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:44:37+01:00",
@@ -7662,7 +7662,7 @@
 			"octgnid": null,
 			"value": "Clubs6",
 			"url": "https://dtdb.co/en/card/24232",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24232.jpg"
+			"imagesrc": "/images/cards/en/24232.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:42:26+01:00",
@@ -7695,7 +7695,7 @@
 			"octgnid": null,
 			"value": "Clubs6",
 			"url": "https://dtdb.co/en/card/24233",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24233.jpg"
+			"imagesrc": "/images/cards/en/24233.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:25:26+01:00",
@@ -7728,7 +7728,7 @@
 			"octgnid": null,
 			"value": "Clubs7",
 			"url": "https://dtdb.co/en/card/24234",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24234.jpg"
+			"imagesrc": "/images/cards/en/24234.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:22:08+01:00",
@@ -7761,7 +7761,7 @@
 			"octgnid": null,
 			"value": "Clubs7",
 			"url": "https://dtdb.co/en/card/24235",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24235.jpg"
+			"imagesrc": "/images/cards/en/24235.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:19:41+01:00",
@@ -7794,7 +7794,7 @@
 			"octgnid": null,
 			"value": "Clubs7",
 			"url": "https://dtdb.co/en/card/24236",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24236.jpg"
+			"imagesrc": "/images/cards/en/24236.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:16:31+01:00",
@@ -7827,7 +7827,7 @@
 			"octgnid": null,
 			"value": "Clubs7",
 			"url": "https://dtdb.co/en/card/24237",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24237.jpg"
+			"imagesrc": "/images/cards/en/24237.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:12:25+01:00",
@@ -7860,7 +7860,7 @@
 			"octgnid": null,
 			"value": "Clubs8",
 			"url": "https://dtdb.co/en/card/24238",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24238.jpg"
+			"imagesrc": "/images/cards/en/24238.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:09:46+01:00",
@@ -7893,7 +7893,7 @@
 			"octgnid": null,
 			"value": "Clubs8",
 			"url": "https://dtdb.co/en/card/24239",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24239.jpg"
+			"imagesrc": "/images/cards/en/24239.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:08:05+01:00",
@@ -7926,7 +7926,7 @@
 			"octgnid": null,
 			"value": "Clubs8",
 			"url": "https://dtdb.co/en/card/24240",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24240.jpg"
+			"imagesrc": "/images/cards/en/24240.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:04:16+01:00",
@@ -7959,7 +7959,7 @@
 			"octgnid": null,
 			"value": "Clubs9",
 			"url": "https://dtdb.co/en/card/24241",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24241.jpg"
+			"imagesrc": "/images/cards/en/24241.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T21:00:02+01:00",
@@ -7992,7 +7992,7 @@
 			"octgnid": null,
 			"value": "Clubs9",
 			"url": "https://dtdb.co/en/card/24242",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24242.jpg"
+			"imagesrc": "/images/cards/en/24242.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T20:57:40+01:00",
@@ -8025,7 +8025,7 @@
 			"octgnid": null,
 			"value": "Clubs9",
 			"url": "https://dtdb.co/en/card/24243",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24243.jpg"
+			"imagesrc": "/images/cards/en/24243.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T20:55:02+01:00",
@@ -8058,7 +8058,7 @@
 			"octgnid": null,
 			"value": "Clubs9",
 			"url": "https://dtdb.co/en/card/24244",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24244.jpg"
+			"imagesrc": "/images/cards/en/24244.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T22:49:47+01:00",
@@ -8091,7 +8091,7 @@
 			"octgnid": null,
 			"value": "Clubs10",
 			"url": "https://dtdb.co/en/card/24245",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24245.jpg"
+			"imagesrc": "/images/cards/en/24245.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T20:43:00+01:00",
@@ -8124,7 +8124,7 @@
 			"octgnid": null,
 			"value": "Clubs10",
 			"url": "https://dtdb.co/en/card/24246",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24246.jpg"
+			"imagesrc": "/images/cards/en/24246.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T20:40:22+01:00",
@@ -8157,7 +8157,7 @@
 			"octgnid": null,
 			"value": "Clubs10",
 			"url": "https://dtdb.co/en/card/24247",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24247.jpg"
+			"imagesrc": "/images/cards/en/24247.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:19:51+01:00",
@@ -8190,7 +8190,7 @@
 			"octgnid": null,
 			"value": "Clubs10",
 			"url": "https://dtdb.co/en/card/24248",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24248.jpg"
+			"imagesrc": "/images/cards/en/24248.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:17:20+01:00",
@@ -8223,7 +8223,7 @@
 			"octgnid": null,
 			"value": "Clubs11",
 			"url": "https://dtdb.co/en/card/24249",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24249.jpg"
+			"imagesrc": "/images/cards/en/24249.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:17:46+01:00",
@@ -8256,7 +8256,7 @@
 			"octgnid": null,
 			"value": "Clubs11",
 			"url": "https://dtdb.co/en/card/24250",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24250.jpg"
+			"imagesrc": "/images/cards/en/24250.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:11:19+01:00",
@@ -8289,7 +8289,7 @@
 			"octgnid": null,
 			"value": "Clubs11",
 			"url": "https://dtdb.co/en/card/24251",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24251.jpg"
+			"imagesrc": "/images/cards/en/24251.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:07:22+01:00",
@@ -8322,7 +8322,7 @@
 			"octgnid": null,
 			"value": "Clubs12",
 			"url": "https://dtdb.co/en/card/24252",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24252.jpg"
+			"imagesrc": "/images/cards/en/24252.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:07:56+01:00",
@@ -8355,7 +8355,7 @@
 			"octgnid": null,
 			"value": "Clubs12",
 			"url": "https://dtdb.co/en/card/24253",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24253.jpg"
+			"imagesrc": "/images/cards/en/24253.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T23:02:49+01:00",
@@ -8388,7 +8388,7 @@
 			"octgnid": null,
 			"value": "Clubs12",
 			"url": "https://dtdb.co/en/card/24254",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24254.jpg"
+			"imagesrc": "/images/cards/en/24254.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T22:55:09+01:00",
@@ -8421,7 +8421,7 @@
 			"octgnid": null,
 			"value": "Clubs13",
 			"url": "https://dtdb.co/en/card/24255",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24255.jpg"
+			"imagesrc": "/images/cards/en/24255.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T22:52:06+01:00",
@@ -8454,7 +8454,7 @@
 			"octgnid": null,
 			"value": "Clubs13",
 			"url": "https://dtdb.co/en/card/24256",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24256.jpg"
+			"imagesrc": "/images/cards/en/24256.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T22:47:06+01:00",
@@ -8487,7 +8487,7 @@
 			"octgnid": null,
 			"value": "Clubs13",
 			"url": "https://dtdb.co/en/card/24257",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24257.jpg"
+			"imagesrc": "/images/cards/en/24257.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T23:02:45+01:00",
@@ -8520,7 +8520,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24258",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24258.jpg"
+			"imagesrc": "/images/cards/en/24258.jpg"
 		},
 		{
 			"last-modified": "2021-12-28T23:02:28+01:00",
@@ -8553,7 +8553,7 @@
 			"octgnid": null,
 			"value": "",
 			"url": "https://dtdb.co/en/card/24259",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24259.jpg"
+			"imagesrc": "/images/cards/en/24259.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T22:36:41+01:00",
@@ -8586,7 +8586,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24260",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24260.jpg"
+			"imagesrc": "/images/cards/en/24260.jpg"
 		},
 		{
 			"last-modified": "2021-12-27T22:32:22+01:00",
@@ -8619,7 +8619,7 @@
 			"octgnid": null,
 			"value": "Spades1",
 			"url": "https://dtdb.co/en/card/24261",
-			"imagesrc": "/web/bundles/dtdbcards/images/cards/en/24261.jpg"
+			"imagesrc": "/images/cards/en/24261.jpg"
 		}
     ]
 }

--- a/packs/DTR.json
+++ b/packs/DTR.json
@@ -39,7 +39,7 @@
             "octgnid": "4137ced8-eb93-4ca6-9253-240b46b15886",
             "value": "",
             "url": "https://dtdb.co/en/card/01001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01001.jpg"
+            "imagesrc": "/images/cards/en/01001.jpg"
         },
         {
             "last-modified": "2015-11-14T21:41:41+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "e6bee3e6-0ccd-40e6-a447-28cb032b7448",
             "value": "",
             "url": "https://dtdb.co/en/card/01002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01002.jpg"
+            "imagesrc": "/images/cards/en/01002.jpg"
         },
         {
             "last-modified": "2017-11-16T18:36:06+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "4f21000a-fb64-4e4b-8e8a-1c5d588dc577",
             "value": "",
             "url": "https://dtdb.co/en/card/01003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01003.jpg"
+            "imagesrc": "/images/cards/en/01003.jpg"
         },
         {
             "last-modified": "2015-11-14T21:57:51+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "f7b4b246-da6f-44e4-9eee-46bb8bfb931a",
             "value": "",
             "url": "https://dtdb.co/en/card/01004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01004.jpg"
+            "imagesrc": "/images/cards/en/01004.jpg"
         },
         {
             "last-modified": "2015-11-14T21:43:55+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "6d31cb7e-a409-4256-8bba-26778de6c5f4",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/01005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01005.jpg"
+            "imagesrc": "/images/cards/en/01005.jpg"
         },
         {
             "last-modified": "2015-11-14T21:44:15+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "18866ac8-9a24-45d7-8f67-df20afdc2dbb",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/01006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01006.jpg"
+            "imagesrc": "/images/cards/en/01006.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "abb271cf-7cbb-4a15-bd45-0458366c6f65",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/01007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01007.jpg"
+            "imagesrc": "/images/cards/en/01007.jpg"
         },
         {
             "last-modified": "2015-11-14T20:39:09+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "1aa58444-fccc-4121-ac6c-482fd48e4b8e",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/01008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01008.jpg"
+            "imagesrc": "/images/cards/en/01008.jpg"
         },
         {
             "last-modified": "2015-11-14T21:57:11+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "91863a08-01d9-4b7e-9eff-0bb62826f433",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/01009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01009.jpg"
+            "imagesrc": "/images/cards/en/01009.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "2871b5b3-fd14-40d1-90e5-f7ea4dae30ba",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/01010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01010.jpg"
+            "imagesrc": "/images/cards/en/01010.jpg"
         },
         {
             "last-modified": "2015-11-14T21:40:52+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "03c50bb2-d027-4d02-b8b6-4bc542dceddb",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/01011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01011.jpg"
+            "imagesrc": "/images/cards/en/01011.jpg"
         },
         {
             "last-modified": "2014-12-16T08:41:02+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "e6db104b-d882-41c5-9285-84ed77a74eac",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/01012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01012.jpg"
+            "imagesrc": "/images/cards/en/01012.jpg"
         },
         {
             "last-modified": "2015-11-14T21:40:00+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "2419a7fc-569e-43bc-b5b7-360d41133e0c",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/01013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01013.jpg"
+            "imagesrc": "/images/cards/en/01013.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "b072a22f-6c55-441f-8cce-4351038ed15c",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/01014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01014.jpg"
+            "imagesrc": "/images/cards/en/01014.jpg"
         },
         {
             "last-modified": "2016-01-15T21:05:17+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "567d93e7-2497-4ddb-aa04-01c927f00bc8",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/01015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01015.jpg"
+            "imagesrc": "/images/cards/en/01015.jpg"
         },
         {
             "last-modified": "2015-11-14T21:40:34+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "9c2ec4f0-65cf-4408-81ff-b377e37f7ecb",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/01016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01016.jpg"
+            "imagesrc": "/images/cards/en/01016.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "fb5f0076-bbb3-486e-9420-02084643592b",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/01017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01017.jpg"
+            "imagesrc": "/images/cards/en/01017.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "2e81c214-539a-4b49-b2d0-69258204b240",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/01018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01018.jpg"
+            "imagesrc": "/images/cards/en/01018.jpg"
         },
         {
             "last-modified": "2016-01-15T21:05:30+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "ab7172e2-0e3f-408d-81ec-afb478385cfe",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/01019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01019.jpg"
+            "imagesrc": "/images/cards/en/01019.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "97061219-899d-4db0-b4a2-ab59bd651df6",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/01020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01020.jpg"
+            "imagesrc": "/images/cards/en/01020.jpg"
         },
         {
             "last-modified": "2015-11-14T22:00:11+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "e22efbb0-e796-4c72-9793-23ed7635dfce",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/01021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01021.jpg"
+            "imagesrc": "/images/cards/en/01021.jpg"
         },
         {
             "last-modified": "2015-11-14T20:54:56+01:00",
@@ -732,7 +732,7 @@
             "octgnid": "27d3649c-fdcf-4b40-83ec-d7d04543cefe",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/01022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01022.jpg"
+            "imagesrc": "/images/cards/en/01022.jpg"
         },
         {
             "last-modified": "2015-11-14T20:37:57+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "44946fbc-1bc0-4a1a-9a55-6138b795bfc8",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/01023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01023.jpg"
+            "imagesrc": "/images/cards/en/01023.jpg"
         },
         {
             "last-modified": "2016-01-15T21:05:45+01:00",
@@ -798,7 +798,7 @@
             "octgnid": "2af1e511-ca73-4f12-a1ae-9a7a340738da",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/01024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01024.jpg"
+            "imagesrc": "/images/cards/en/01024.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "d9586ca6-50bc-446e-aa3b-fc84b0545dcd",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/01025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01025.jpg"
+            "imagesrc": "/images/cards/en/01025.jpg"
         },
         {
             "last-modified": "2015-11-14T21:47:35+01:00",
@@ -864,7 +864,7 @@
             "octgnid": "f8437fa5-c088-41b2-b6c9-2060f69ec7be",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/01026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01026.jpg"
+            "imagesrc": "/images/cards/en/01026.jpg"
         },
         {
             "last-modified": "2015-11-14T21:28:26+01:00",
@@ -897,7 +897,7 @@
             "octgnid": "8e50a03b-b42c-4207-9d0d-7a144ad31e3b",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/01027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01027.jpg"
+            "imagesrc": "/images/cards/en/01027.jpg"
         },
         {
             "last-modified": "2015-11-14T21:32:31+01:00",
@@ -930,7 +930,7 @@
             "octgnid": "feb37a5b-a95c-4c03-92e0-acd27d7a3ef3",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/01028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01028.jpg"
+            "imagesrc": "/images/cards/en/01028.jpg"
         },
         {
             "last-modified": "2015-11-14T21:40:16+01:00",
@@ -963,7 +963,7 @@
             "octgnid": "0c0087d0-6356-44a4-8237-15f86573716a",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/01029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01029.jpg"
+            "imagesrc": "/images/cards/en/01029.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "c263b2ff-3d4b-4beb-aa3b-d4e1f72e56ff",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/01030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01030.jpg"
+            "imagesrc": "/images/cards/en/01030.jpg"
         },
         {
             "last-modified": "2015-11-14T21:39:40+01:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "c57efc28-77d3-492b-81ad-f3c5ce130041",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/01031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01031.jpg"
+            "imagesrc": "/images/cards/en/01031.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:20+01:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "f64c8b68-0d63-4f5d-a898-f38576024f75",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/01032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01032.jpg"
+            "imagesrc": "/images/cards/en/01032.jpg"
         },
         {
             "last-modified": "2016-01-15T21:06:22+01:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "cb15bd27-76a2-48db-b324-99589b14982b",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/01033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01033.jpg"
+            "imagesrc": "/images/cards/en/01033.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "4ad6e3d4-3c6c-43a4-a612-293586609150",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/01034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01034.jpg"
+            "imagesrc": "/images/cards/en/01034.jpg"
         },
         {
             "last-modified": "2015-11-14T20:38:23+01:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "dfd2d635-4b88-4cea-9939-14deec3896cf",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/01035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01035.jpg"
+            "imagesrc": "/images/cards/en/01035.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "fa1e44a1-2064-4d70-8286-854d80b50da2",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/01036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01036.jpg"
+            "imagesrc": "/images/cards/en/01036.jpg"
         },
         {
             "last-modified": "2015-11-14T21:41:51+01:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "8ed33c69-c79e-4ced-a180-3fe57bf0d25d",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/01037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01037.jpg"
+            "imagesrc": "/images/cards/en/01037.jpg"
         },
         {
             "last-modified": "2016-01-15T21:06:43+01:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "3bd5addb-ac4e-45aa-9971-bd445222344e",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/01038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01038.jpg"
+            "imagesrc": "/images/cards/en/01038.jpg"
         },
         {
             "last-modified": "2015-11-14T21:54:55+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "e686782d-1d7c-464d-82ed-910fcaa2945d",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/01039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01039.jpg"
+            "imagesrc": "/images/cards/en/01039.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "c3638e9f-f664-43a6-abe0-645aab082455",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/01040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01040.jpg"
+            "imagesrc": "/images/cards/en/01040.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "d9d621f3-1905-4a99-8f5a-f1feb9639a64",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/01041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01041.jpg"
+            "imagesrc": "/images/cards/en/01041.jpg"
         },
         {
             "last-modified": "2015-06-28T20:05:05+02:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "f95140da-3b72-4210-95fb-bfe7efe2cca4",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/01042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01042.jpg"
+            "imagesrc": "/images/cards/en/01042.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "28b5d3c7-bb58-4b63-aae5-659e86fee876",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/01043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01043.jpg"
+            "imagesrc": "/images/cards/en/01043.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "8209b72a-15c4-440b-9ad7-8614a9d2f452",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/01044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01044.jpg"
+            "imagesrc": "/images/cards/en/01044.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "5d610a44-7f13-4333-a941-ee5e1fa2fb37",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/01045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01045.jpg"
+            "imagesrc": "/images/cards/en/01045.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1524,7 +1524,7 @@
             "octgnid": "65d4cd16-fc61-4412-8a39-a6ad384fa766",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/01046",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01046.jpg"
+            "imagesrc": "/images/cards/en/01046.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1557,7 +1557,7 @@
             "octgnid": "d677fa1e-61f3-422a-9b95-745692c7b800",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/01047",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01047.jpg"
+            "imagesrc": "/images/cards/en/01047.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1590,7 +1590,7 @@
             "octgnid": "d9a3a80d-deef-47a7-9a5a-e1c7e0109697",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/01048",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01048.jpg"
+            "imagesrc": "/images/cards/en/01048.jpg"
         },
         {
             "last-modified": "2015-11-14T21:59:19+01:00",
@@ -1623,7 +1623,7 @@
             "octgnid": "03341e26-42b4-4545-897e-8626de5e3dd7",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/01049",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01049.jpg"
+            "imagesrc": "/images/cards/en/01049.jpg"
         },
         {
             "last-modified": "2015-11-14T20:38:49+01:00",
@@ -1656,7 +1656,7 @@
             "octgnid": "ecfa0567-5576-427f-a829-a049e817f4b0",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/01050",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01050.jpg"
+            "imagesrc": "/images/cards/en/01050.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -1689,7 +1689,7 @@
             "octgnid": "335662d9-0d7c-430e-a556-11693385f5aa",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/01051",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01051.jpg"
+            "imagesrc": "/images/cards/en/01051.jpg"
         },
         {
             "last-modified": "2015-11-14T21:30:45+01:00",
@@ -1722,7 +1722,7 @@
             "octgnid": "36c91361-cab3-4988-bed2-2c3401746695",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/01052",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01052.jpg"
+            "imagesrc": "/images/cards/en/01052.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1755,7 +1755,7 @@
             "octgnid": "077d03fd-1509-43a2-8844-c2bd8d62b837",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/01053",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01053.jpg"
+            "imagesrc": "/images/cards/en/01053.jpg"
         },
         {
             "last-modified": "2015-11-14T21:28:55+01:00",
@@ -1788,7 +1788,7 @@
             "octgnid": "f149dcc9-44a4-4399-8786-62d2496559e4",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/01054",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01054.jpg"
+            "imagesrc": "/images/cards/en/01054.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -1821,7 +1821,7 @@
             "octgnid": "3c904ee6-15de-4478-8837-61e394bb31ee",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/01055",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01055.jpg"
+            "imagesrc": "/images/cards/en/01055.jpg"
         },
         {
             "last-modified": "2015-11-14T21:46:57+01:00",
@@ -1854,7 +1854,7 @@
             "octgnid": "a9b3a2b8-9f22-474d-b35a-59a380c0921f",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/01056",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01056.jpg"
+            "imagesrc": "/images/cards/en/01056.jpg"
         },
         {
             "last-modified": "2015-11-14T21:30:23+01:00",
@@ -1887,7 +1887,7 @@
             "octgnid": "972201b6-4fc1-44ed-8ed0-a16b1d609265",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/01057",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01057.jpg"
+            "imagesrc": "/images/cards/en/01057.jpg"
         },
         {
             "last-modified": "2015-11-14T21:58:33+01:00",
@@ -1920,7 +1920,7 @@
             "octgnid": "7378c899-a9c3-46d4-8d68-f452c9640734",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/01058",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01058.jpg"
+            "imagesrc": "/images/cards/en/01058.jpg"
         },
         {
             "last-modified": "2014-12-16T08:41:15+01:00",
@@ -1953,7 +1953,7 @@
             "octgnid": "94c55a0c-1599-4eee-8699-ad9c63e375a1",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/01059",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01059.jpg"
+            "imagesrc": "/images/cards/en/01059.jpg"
         },
         {
             "last-modified": "2015-11-14T22:00:22+01:00",
@@ -1986,7 +1986,7 @@
             "octgnid": "b999405d-e2ca-4703-beda-67f9697fc977",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/01060",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01060.jpg"
+            "imagesrc": "/images/cards/en/01060.jpg"
         },
         {
             "last-modified": "2015-11-14T20:42:20+01:00",
@@ -2019,7 +2019,7 @@
             "octgnid": "232f0a41-2ef5-47a0-9c32-6ccb8eb3c84e",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/01061",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01061.jpg"
+            "imagesrc": "/images/cards/en/01061.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -2052,7 +2052,7 @@
             "octgnid": "9fe6ced8-a97c-49e8-8806-0ba465f535f6",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/01062",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01062.jpg"
+            "imagesrc": "/images/cards/en/01062.jpg"
         },
         {
             "last-modified": "2015-11-14T20:44:37+01:00",
@@ -2085,7 +2085,7 @@
             "octgnid": "57528427-b65a-4056-9fea-082bba8ef4a9",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/01063",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01063.jpg"
+            "imagesrc": "/images/cards/en/01063.jpg"
         },
         {
             "last-modified": "2015-11-14T21:45:40+01:00",
@@ -2118,7 +2118,7 @@
             "octgnid": "ed26a010-8947-456f-b8f7-2741e083b54a",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/01064",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01064.jpg"
+            "imagesrc": "/images/cards/en/01064.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -2151,7 +2151,7 @@
             "octgnid": "b4442f8d-71d0-4d12-9000-4df27ea78643",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/01065",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01065.jpg"
+            "imagesrc": "/images/cards/en/01065.jpg"
         },
         {
             "last-modified": "2015-11-14T21:55:56+01:00",
@@ -2184,7 +2184,7 @@
             "octgnid": "2c51b78f-b130-4663-9c78-0cc69a20a059",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/01066",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01066.jpg"
+            "imagesrc": "/images/cards/en/01066.jpg"
         },
         {
             "last-modified": "2014-12-16T08:41:46+01:00",
@@ -2217,7 +2217,7 @@
             "octgnid": "2ad321e1-eaa0-4984-bdd0-a8d088045588",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/01067",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01067.jpg"
+            "imagesrc": "/images/cards/en/01067.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -2250,7 +2250,7 @@
             "octgnid": "2cd7a17c-ce6a-4ffd-92b0-06fe310c7d6c",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/01068",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01068.jpg"
+            "imagesrc": "/images/cards/en/01068.jpg"
         },
         {
             "last-modified": "2015-11-14T20:53:53+01:00",
@@ -2283,7 +2283,7 @@
             "octgnid": "ec741b63-8ac4-4b5a-9767-9854e05b91c3",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/01069",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01069.jpg"
+            "imagesrc": "/images/cards/en/01069.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -2316,7 +2316,7 @@
             "octgnid": "69ccb375-f660-4d91-a405-2103b578f100",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/01070",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01070.jpg"
+            "imagesrc": "/images/cards/en/01070.jpg"
         },
         {
             "last-modified": "2017-03-25T11:37:41+01:00",
@@ -2349,7 +2349,7 @@
             "octgnid": "9cba89ca-5a3f-4dad-aff0-91d62581dc31",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/01071",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01071.jpg"
+            "imagesrc": "/images/cards/en/01071.jpg"
         },
         {
             "last-modified": "2015-11-14T21:57:30+01:00",
@@ -2382,7 +2382,7 @@
             "octgnid": "75e35d17-de1e-457f-88e0-42e2bc9301bc",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/01072",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01072.jpg"
+            "imagesrc": "/images/cards/en/01072.jpg"
         },
         {
             "last-modified": "2015-11-14T20:44:22+01:00",
@@ -2415,7 +2415,7 @@
             "octgnid": "6560b478-c5fe-4717-a2d1-40ef7c6effa6",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/01073",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01073.jpg"
+            "imagesrc": "/images/cards/en/01073.jpg"
         },
         {
             "last-modified": "2015-11-14T21:58:42+01:00",
@@ -2448,7 +2448,7 @@
             "octgnid": "d340ff50-aec3-4800-a993-c76c954c34a9",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/01074",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01074.jpg"
+            "imagesrc": "/images/cards/en/01074.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -2481,7 +2481,7 @@
             "octgnid": "0eeba3c3-792a-4d39-879a-aab77b0f3981",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/01075",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01075.jpg"
+            "imagesrc": "/images/cards/en/01075.jpg"
         },
         {
             "last-modified": "2017-03-25T11:43:35+01:00",
@@ -2514,7 +2514,7 @@
             "octgnid": "a8843dcd-cd66-4f38-b6a9-12fbf5fd8bba",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/01076",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01076.jpg"
+            "imagesrc": "/images/cards/en/01076.jpg"
         },
         {
             "last-modified": "2015-11-14T21:30:11+01:00",
@@ -2547,7 +2547,7 @@
             "octgnid": "45438749-ab3b-4f88-adb3-8c3cc65cfd54",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/01077",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01077.jpg"
+            "imagesrc": "/images/cards/en/01077.jpg"
         },
         {
             "last-modified": "2015-11-14T21:57:40+01:00",
@@ -2580,7 +2580,7 @@
             "octgnid": "84e33474-5247-4969-b7d1-e335b720a566",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/01078",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01078.jpg"
+            "imagesrc": "/images/cards/en/01078.jpg"
         },
         {
             "last-modified": "2015-11-14T21:48:07+01:00",
@@ -2613,7 +2613,7 @@
             "octgnid": "fa907076-61c7-4f1f-b9a4-87a1df59bfae",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/01079",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01079.jpg"
+            "imagesrc": "/images/cards/en/01079.jpg"
         },
         {
             "last-modified": "2015-11-14T21:56:52+01:00",
@@ -2646,7 +2646,7 @@
             "octgnid": "08d1664d-5d98-4093-88c3-e93b0c6cc84f",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/01080",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01080.jpg"
+            "imagesrc": "/images/cards/en/01080.jpg"
         },
         {
             "last-modified": "2015-11-14T21:45:10+01:00",
@@ -2679,7 +2679,7 @@
             "octgnid": "2dbddcbc-d228-451d-8cde-32b65abe769e",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/01081",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01081.jpg"
+            "imagesrc": "/images/cards/en/01081.jpg"
         },
         {
             "last-modified": "2016-01-15T21:08:33+01:00",
@@ -2712,7 +2712,7 @@
             "octgnid": "a914540e-8564-44a4-b4cf-64f9f392218b",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/01082",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01082.jpg"
+            "imagesrc": "/images/cards/en/01082.jpg"
         },
         {
             "last-modified": "2014-12-16T08:45:33+01:00",
@@ -2745,7 +2745,7 @@
             "octgnid": "022097bf-7e34-4b78-b7ca-3d60ca13eddd",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/01083",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01083.jpg"
+            "imagesrc": "/images/cards/en/01083.jpg"
         },
         {
             "last-modified": "2015-11-14T21:55:27+01:00",
@@ -2778,7 +2778,7 @@
             "octgnid": "ac681d62-c7df-469f-8ac6-80816c781136",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/01084",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01084.jpg"
+            "imagesrc": "/images/cards/en/01084.jpg"
         },
         {
             "last-modified": "2015-11-14T22:00:02+01:00",
@@ -2811,7 +2811,7 @@
             "octgnid": "80d43d02-7885-4e2e-98e5-62ba2b189155",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/01085",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01085.jpg"
+            "imagesrc": "/images/cards/en/01085.jpg"
         },
         {
             "last-modified": "2015-11-14T21:44:41+01:00",
@@ -2844,7 +2844,7 @@
             "octgnid": "9aa68e21-1eee-4d44-993e-dd8cf60ed613",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/01086",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01086.jpg"
+            "imagesrc": "/images/cards/en/01086.jpg"
         },
         {
             "last-modified": "2016-01-15T21:08:54+01:00",
@@ -2877,7 +2877,7 @@
             "octgnid": "c8453a00-e4f9-4dbe-922c-3daf79586cef",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/01087",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01087.jpg"
+            "imagesrc": "/images/cards/en/01087.jpg"
         },
         {
             "last-modified": "2015-11-14T21:49:25+01:00",
@@ -2910,7 +2910,7 @@
             "octgnid": "ff6f51e6-ab2f-4fb9-8670-1715b278cc8c",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/01088",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01088.jpg"
+            "imagesrc": "/images/cards/en/01088.jpg"
         },
         {
             "last-modified": "2017-03-25T11:36:51+01:00",
@@ -2943,7 +2943,7 @@
             "octgnid": "239ef52d-12a1-47b6-8838-28a8c021a251",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/01089",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01089.jpg"
+            "imagesrc": "/images/cards/en/01089.jpg"
         },
         {
             "last-modified": "2015-11-14T21:46:19+01:00",
@@ -2976,7 +2976,7 @@
             "octgnid": "9e712f98-1a8b-4137-997e-e61e6549102c",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/01090",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01090.jpg"
+            "imagesrc": "/images/cards/en/01090.jpg"
         },
         {
             "last-modified": "2015-11-14T21:29:24+01:00",
@@ -3009,7 +3009,7 @@
             "octgnid": "c20de5e3-daea-4dce-a8ce-eaa5349c8187",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/01091",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01091.jpg"
+            "imagesrc": "/images/cards/en/01091.jpg"
         },
         {
             "last-modified": "2015-11-14T21:29:37+01:00",
@@ -3042,7 +3042,7 @@
             "octgnid": "40302c3e-668e-474f-a2ae-7ab1bbdf9d63",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/01092",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01092.jpg"
+            "imagesrc": "/images/cards/en/01092.jpg"
         },
         {
             "last-modified": "2016-01-15T21:10:24+01:00",
@@ -3075,7 +3075,7 @@
             "octgnid": "6409f8c3-8fcc-4b31-96e6-96318f629230",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/01093",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01093.jpg"
+            "imagesrc": "/images/cards/en/01093.jpg"
         },
         {
             "last-modified": "2016-01-15T21:11:04+01:00",
@@ -3108,7 +3108,7 @@
             "octgnid": "aa1dec3f-9913-4bf1-bbcd-5d29457f6a80",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/01094",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01094.jpg"
+            "imagesrc": "/images/cards/en/01094.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -3141,7 +3141,7 @@
             "octgnid": "89686c7d-7845-48ef-bf10-2bf38563522f",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/01095",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01095.jpg"
+            "imagesrc": "/images/cards/en/01095.jpg"
         },
         {
             "last-modified": "2016-01-15T21:25:03+01:00",
@@ -3174,7 +3174,7 @@
             "octgnid": "0482af4d-f834-4f73-88fc-9f57e44c465a",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/01096",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01096.jpg"
+            "imagesrc": "/images/cards/en/01096.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -3207,7 +3207,7 @@
             "octgnid": "efaf839b-f06f-4aff-982b-a99ae00f340c",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/01097",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01097.jpg"
+            "imagesrc": "/images/cards/en/01097.jpg"
         },
         {
             "last-modified": "2015-11-14T21:42:01+01:00",
@@ -3240,7 +3240,7 @@
             "octgnid": "677bbf45-1f98-49aa-b8cc-b63b8f3d5146",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/01098",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01098.jpg"
+            "imagesrc": "/images/cards/en/01098.jpg"
         },
         {
             "last-modified": "2015-11-14T20:41:52+01:00",
@@ -3273,7 +3273,7 @@
             "octgnid": "20376d1c-4d9a-42ce-8b34-a95a175f1623",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/01099",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01099.jpg"
+            "imagesrc": "/images/cards/en/01099.jpg"
         },
         {
             "last-modified": "2015-11-14T21:55:45+01:00",
@@ -3306,7 +3306,7 @@
             "octgnid": "bf1c8173-843a-4a20-be3b-f4ae650cfdd2",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/01100",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01100.jpg"
+            "imagesrc": "/images/cards/en/01100.jpg"
         },
         {
             "last-modified": "2015-11-14T20:38:10+01:00",
@@ -3339,7 +3339,7 @@
             "octgnid": "cf239340-c794-4a91-a241-e3cbafec2f6e",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/01101",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01101.jpg"
+            "imagesrc": "/images/cards/en/01101.jpg"
         },
         {
             "last-modified": "2015-11-14T21:55:13+01:00",
@@ -3372,7 +3372,7 @@
             "octgnid": "f9714fff-14d9-433c-b2cc-05068006c388",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/01102",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01102.jpg"
+            "imagesrc": "/images/cards/en/01102.jpg"
         },
         {
             "last-modified": "2015-11-14T20:43:00+01:00",
@@ -3405,7 +3405,7 @@
             "octgnid": "597ff0fc-a578-4215-9c6d-c5452d387870",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/01103",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01103.jpg"
+            "imagesrc": "/images/cards/en/01103.jpg"
         },
         {
             "last-modified": "2015-11-14T21:48:24+01:00",
@@ -3438,7 +3438,7 @@
             "octgnid": "0ab4453e-e9bd-4899-96e1-1eb6757ecd94",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/01104",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01104.jpg"
+            "imagesrc": "/images/cards/en/01104.jpg"
         },
         {
             "last-modified": "2015-11-14T21:28:38+01:00",
@@ -3471,7 +3471,7 @@
             "octgnid": "2ae1a463-0106-426c-b9fd-6bb22df27aff",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/01105",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01105.jpg"
+            "imagesrc": "/images/cards/en/01105.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:51+01:00",
@@ -3504,7 +3504,7 @@
             "octgnid": "fd307ab6-2c39-438c-8b2e-b6ffd74b15bc",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/01106",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01106.jpg"
+            "imagesrc": "/images/cards/en/01106.jpg"
         },
         {
             "last-modified": "2015-11-14T21:41:26+01:00",
@@ -3537,7 +3537,7 @@
             "octgnid": "aced4a1e-d5c9-423d-8d47-892c19c6a859",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/01107",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01107.jpg"
+            "imagesrc": "/images/cards/en/01107.jpg"
         },
         {
             "last-modified": "2015-11-14T20:43:50+01:00",
@@ -3570,7 +3570,7 @@
             "octgnid": "1a3e8af5-302b-47e5-8c30-901b8ed995bc",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/01108",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01108.jpg"
+            "imagesrc": "/images/cards/en/01108.jpg"
         },
         {
             "last-modified": "2015-11-14T21:43:02+01:00",
@@ -3603,7 +3603,7 @@
             "octgnid": "9ead8579-7077-45e4-a44d-cf284f55b3e5",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/01109",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01109.jpg"
+            "imagesrc": "/images/cards/en/01109.jpg"
         },
         {
             "last-modified": "2016-01-15T21:13:07+01:00",
@@ -3636,7 +3636,7 @@
             "octgnid": "d4133356-c738-4b89-82ac-9a6d5e35a744",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/01110",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01110.jpg"
+            "imagesrc": "/images/cards/en/01110.jpg"
         },
         {
             "last-modified": "2015-11-14T20:41:37+01:00",
@@ -3669,7 +3669,7 @@
             "octgnid": "57763c43-994c-4682-ab8d-d8d732fe915e",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/01111",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01111.jpg"
+            "imagesrc": "/images/cards/en/01111.jpg"
         },
         {
             "last-modified": "2016-01-15T21:13:25+01:00",
@@ -3702,7 +3702,7 @@
             "octgnid": "8649f082-f7cd-414d-b360-9b1b72f6172b",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/01112",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01112.jpg"
+            "imagesrc": "/images/cards/en/01112.jpg"
         },
         {
             "last-modified": "2015-11-14T21:56:33+01:00",
@@ -3735,7 +3735,7 @@
             "octgnid": "fcc6f54f-e9d1-40a6-9870-1be438eeef12",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/01113",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01113.jpg"
+            "imagesrc": "/images/cards/en/01113.jpg"
         },
         {
             "last-modified": "2015-11-14T20:38:35+01:00",
@@ -3768,7 +3768,7 @@
             "octgnid": "cc2092bd-b575-4a26-8e96-aa13f8736d75",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/01114",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01114.jpg"
+            "imagesrc": "/images/cards/en/01114.jpg"
         },
         {
             "last-modified": "2016-01-15T21:32:28+01:00",
@@ -3801,7 +3801,7 @@
             "octgnid": "0c41f0c4-2491-4723-8cf9-d8ab3e071e05",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/01115",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01115.jpg"
+            "imagesrc": "/images/cards/en/01115.jpg"
         },
         {
             "last-modified": "2015-11-14T21:59:51+01:00",
@@ -3834,7 +3834,7 @@
             "octgnid": "b3140484-bfe8-4eb4-963f-27e8d9334b8a",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/01116",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01116.jpg"
+            "imagesrc": "/images/cards/en/01116.jpg"
         },
         {
             "last-modified": "2015-11-14T20:42:33+01:00",
@@ -3867,7 +3867,7 @@
             "octgnid": "9a18cd02-63dd-4381-ba9f-49d80fac935a",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/01117",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01117.jpg"
+            "imagesrc": "/images/cards/en/01117.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:41+01:00",
@@ -3900,7 +3900,7 @@
             "octgnid": "5c5b6579-a2de-419d-b531-6d08c1eba77d",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/01118",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01118.jpg"
+            "imagesrc": "/images/cards/en/01118.jpg"
         },
         {
             "last-modified": "2015-11-14T21:46:37+01:00",
@@ -3933,7 +3933,7 @@
             "octgnid": "1536769f-42f4-4840-9360-96d2e7e3f366",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/01119",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01119.jpg"
+            "imagesrc": "/images/cards/en/01119.jpg"
         },
         {
             "last-modified": "2015-11-14T20:55:28+01:00",
@@ -3966,7 +3966,7 @@
             "octgnid": "9c4f6a3b-70e0-40d8-adde-e26c4e5eab12",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/01120",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01120.jpg"
+            "imagesrc": "/images/cards/en/01120.jpg"
         },
         {
             "last-modified": "2017-03-25T11:40:03+01:00",
@@ -3999,7 +3999,7 @@
             "octgnid": "460fcab1-be68-41f1-90bf-41ee11aa17c4",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/01121",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01121.jpg"
+            "imagesrc": "/images/cards/en/01121.jpg"
         },
         {
             "last-modified": "2015-11-14T21:44:58+01:00",
@@ -4032,7 +4032,7 @@
             "octgnid": "1950bc30-abf5-4ed4-b20a-e56bb4032de0",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/01122",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01122.jpg"
+            "imagesrc": "/images/cards/en/01122.jpg"
         },
         {
             "last-modified": "2015-11-14T21:41:04+01:00",
@@ -4065,7 +4065,7 @@
             "octgnid": "e11367a5-6fad-40a4-b22a-a2571eb7c330",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/01123",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01123.jpg"
+            "imagesrc": "/images/cards/en/01123.jpg"
         },
         {
             "last-modified": "2016-01-15T21:15:43+01:00",
@@ -4098,7 +4098,7 @@
             "octgnid": "b5fbbe61-aba3-4de7-b501-4feb1f9cf203",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/01124",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01124.jpg"
+            "imagesrc": "/images/cards/en/01124.jpg"
         },
         {
             "last-modified": "2016-01-15T21:16:09+01:00",
@@ -4131,7 +4131,7 @@
             "octgnid": "3a1296d2-79f5-4a8a-9ea3-cabc4564e9eb",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/01125",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01125.jpg"
+            "imagesrc": "/images/cards/en/01125.jpg"
         },
         {
             "last-modified": "2015-11-14T20:44:04+01:00",
@@ -4164,7 +4164,7 @@
             "octgnid": "5cd89aa8-b973-4fa6-be81-087b5e369ed4",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/01126",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01126.jpg"
+            "imagesrc": "/images/cards/en/01126.jpg"
         },
         {
             "last-modified": "2015-11-14T21:49:05+01:00",
@@ -4197,7 +4197,7 @@
             "octgnid": "0672772c-7380-4b36-be78-1c7b23b3d950",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/01127",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01127.jpg"
+            "imagesrc": "/images/cards/en/01127.jpg"
         },
         {
             "last-modified": "2015-11-14T21:52:19+01:00",
@@ -4230,7 +4230,7 @@
             "octgnid": "d7e770dd-793f-4a53-a404-e3873a762ad1",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/01128",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01128.jpg"
+            "imagesrc": "/images/cards/en/01128.jpg"
         },
         {
             "last-modified": "2015-11-14T20:45:00+01:00",
@@ -4263,7 +4263,7 @@
             "octgnid": "3029937b-17cc-4c87-a109-9888747f3134",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/01129",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01129.jpg"
+            "imagesrc": "/images/cards/en/01129.jpg"
         },
         {
             "last-modified": "2015-11-14T21:29:52+01:00",
@@ -4296,7 +4296,7 @@
             "octgnid": "51b788af-7a36-4af4-9f2e-302441634966",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/01130",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01130.jpg"
+            "imagesrc": "/images/cards/en/01130.jpg"
         },
         {
             "last-modified": "2015-11-14T21:42:44+01:00",
@@ -4329,7 +4329,7 @@
             "octgnid": "72853004-7ce4-4d66-a486-fc28bb87a048",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/01131",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01131.jpg"
+            "imagesrc": "/images/cards/en/01131.jpg"
         },
         {
             "last-modified": "2015-11-14T21:29:05+01:00",
@@ -4362,7 +4362,7 @@
             "octgnid": "b61dc1ab-393c-4827-a6ec-4f9ffb870491",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/01132",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01132.jpg"
+            "imagesrc": "/images/cards/en/01132.jpg"
         },
         {
             "last-modified": "2015-11-14T21:48:45+01:00",
@@ -4395,7 +4395,7 @@
             "octgnid": "9ef9abea-373c-4265-b7fc-3d8391095f64",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/01133",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01133.jpg"
+            "imagesrc": "/images/cards/en/01133.jpg"
         },
         {
             "last-modified": "2015-11-14T21:59:43+01:00",
@@ -4428,7 +4428,7 @@
             "octgnid": "1f230385-e07c-43e2-a205-79547ce18380",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/01134",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01134.jpg"
+            "imagesrc": "/images/cards/en/01134.jpg"
         },
         {
             "last-modified": "2015-11-14T20:37:26+01:00",
@@ -4461,7 +4461,7 @@
             "octgnid": "6656eabf-4a69-4854-950d-f30d7771c4ae",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/01135",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01135.jpg"
+            "imagesrc": "/images/cards/en/01135.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:31+01:00",
@@ -4494,7 +4494,7 @@
             "octgnid": "7a949a25-df55-47e3-9d6e-674b51cc0f0f",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/01136",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01136.jpg"
+            "imagesrc": "/images/cards/en/01136.jpg"
         },
         {
             "last-modified": "2016-01-15T21:16:19+01:00",
@@ -4527,7 +4527,7 @@
             "octgnid": "7779228b-f33c-4c36-ae90-17fdf54cd142",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/01137",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01137.jpg"
+            "imagesrc": "/images/cards/en/01137.jpg"
         },
         {
             "last-modified": "2015-11-14T20:54:04+01:00",
@@ -4560,7 +4560,7 @@
             "octgnid": "37d550e3-6bb5-4744-a544-fcbba0153780",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/01138",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01138.jpg"
+            "imagesrc": "/images/cards/en/01138.jpg"
         },
         {
             "last-modified": "2015-11-14T21:44:05+01:00",
@@ -4593,7 +4593,7 @@
             "octgnid": "00a45909-a052-457d-a71b-119e415c03c7",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/01139",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01139.jpg"
+            "imagesrc": "/images/cards/en/01139.jpg"
         },
         {
             "last-modified": "2015-11-14T21:56:43+01:00",
@@ -4626,7 +4626,7 @@
             "octgnid": "452fd385-a516-45d9-8408-8628f4788fa5",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/01140",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01140.jpg"
+            "imagesrc": "/images/cards/en/01140.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:08+01:00",
@@ -4659,7 +4659,7 @@
             "octgnid": "74fbc995-aeca-4026-a4f4-682684e6feb1",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/01141",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01141.jpg"
+            "imagesrc": "/images/cards/en/01141.jpg"
         },
         {
             "last-modified": "2015-11-14T21:46:48+01:00",
@@ -4692,7 +4692,7 @@
             "octgnid": "498d4eca-db79-40db-9a42-cc053abcfc43",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/01142",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01142.jpg"
+            "imagesrc": "/images/cards/en/01142.jpg"
         },
         {
             "last-modified": "2015-11-14T20:37:44+01:00",
@@ -4725,7 +4725,7 @@
             "octgnid": "19d8b876-0ed9-42fc-90b9-4840e0d46521",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/01143",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01143.jpg"
+            "imagesrc": "/images/cards/en/01143.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -4758,7 +4758,7 @@
             "octgnid": "a630aa27-9ba9-4e38-86b4-83cade3a7546",
             "value": "",
             "url": "https://dtdb.co/en/card/01144",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01144.jpg"
+            "imagesrc": "/images/cards/en/01144.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -4791,7 +4791,7 @@
             "octgnid": "1b4e7dec-5ff8-4407-9932-30ffd30c91fe",
             "value": "",
             "url": "https://dtdb.co/en/card/01145",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01145.jpg"
+            "imagesrc": "/images/cards/en/01145.jpg"
         },
         {
             "last-modified": "2014-10-02T14:19:41+02:00",
@@ -4824,7 +4824,7 @@
             "octgnid": null,
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/01146",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/01146.jpg"
+            "imagesrc": "/images/cards/en/01146.jpg"
         }
     ]
 }

--- a/packs/EDS.json
+++ b/packs/EDS.json
@@ -39,7 +39,7 @@
             "octgnid": "13cdc52f-986e-4f3b-b053-c3261267790d",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/04001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04001.jpg"
+            "imagesrc": "/images/cards/en/04001.jpg"
         },
         {
             "last-modified": "2015-02-09T11:01:58+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "d90e5abe-ed12-4dad-9007-16aa47afa2cc",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/04002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04002.jpg"
+            "imagesrc": "/images/cards/en/04002.jpg"
         },
         {
             "last-modified": "2015-02-09T11:01:58+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "f1012bb4-2429-4ec3-9b89-6ebcb3f94184",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/04003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04003.jpg"
+            "imagesrc": "/images/cards/en/04003.jpg"
         },
         {
             "last-modified": "2015-09-28T20:38:46+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "19fc7ff8-d4da-492f-8a41-7a838490c9e4",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/04004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04004.jpg"
+            "imagesrc": "/images/cards/en/04004.jpg"
         },
         {
             "last-modified": "2015-09-28T20:32:37+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "95b9d8df-a95d-4b5e-aeed-98f8e99ca5a5",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/04005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04005.jpg"
+            "imagesrc": "/images/cards/en/04005.jpg"
         },
         {
             "last-modified": "2015-09-28T20:33:00+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "33b97a88-5b7f-4073-8e30-5c66da9060c5",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/04006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04006.jpg"
+            "imagesrc": "/images/cards/en/04006.jpg"
         },
         {
             "last-modified": "2015-10-03T12:05:47+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "28c37361-c5ac-4561-b1bc-5f41113e0625",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/04007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04007.jpg"
+            "imagesrc": "/images/cards/en/04007.jpg"
         },
         {
             "last-modified": "2015-02-09T11:01:58+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "cd99ead2-3b50-4989-8331-59f76b5edb0b",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/04008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04008.jpg"
+            "imagesrc": "/images/cards/en/04008.jpg"
         },
         {
             "last-modified": "2017-12-13T13:24:12+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "36c80330-39fc-4fdc-8736-4c8d47758063",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/04009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04009.jpg"
+            "imagesrc": "/images/cards/en/04009.jpg"
         },
         {
             "last-modified": "2015-09-28T20:42:06+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "144991c0-f3f4-4914-a075-ab2093991411",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/04010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04010.jpg"
+            "imagesrc": "/images/cards/en/04010.jpg"
         },
         {
             "last-modified": "2015-09-28T20:33:41+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "6b01cb98-4ae3-4b6e-b7d1-29fe035c9e2d",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/04011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04011.jpg"
+            "imagesrc": "/images/cards/en/04011.jpg"
         },
         {
             "last-modified": "2015-09-28T20:34:02+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "90568a28-333b-4836-b55c-8ebbef266ad1",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/04012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04012.jpg"
+            "imagesrc": "/images/cards/en/04012.jpg"
         },
         {
             "last-modified": "2015-09-28T20:34:21+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "1f6dc79e-65ad-4727-bf8e-1c42eee98fe1",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/04013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04013.jpg"
+            "imagesrc": "/images/cards/en/04013.jpg"
         },
         {
             "last-modified": "2015-09-28T20:34:52+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "9687ab08-0ae9-4a15-8304-6e9797edc87e",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/04014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04014.jpg"
+            "imagesrc": "/images/cards/en/04014.jpg"
         },
         {
             "last-modified": "2017-12-13T13:27:19+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "28d66d3e-bc96-4c2c-9ebb-38dfabceb440",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/04015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04015.jpg"
+            "imagesrc": "/images/cards/en/04015.jpg"
         },
         {
             "last-modified": "2015-10-03T12:06:29+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "68310bec-735a-46bc-be6c-949e26bc5758",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/04016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04016.jpg"
+            "imagesrc": "/images/cards/en/04016.jpg"
         },
         {
             "last-modified": "2015-09-28T20:35:52+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "146c6a48-ffb5-4201-b07e-74e5560da771",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/04017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04017.jpg"
+            "imagesrc": "/images/cards/en/04017.jpg"
         },
         {
             "last-modified": "2015-10-03T12:06:56+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "791de7a5-3292-43cd-b907-40f737dc8600",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/04018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04018.jpg"
+            "imagesrc": "/images/cards/en/04018.jpg"
         },
         {
             "last-modified": "2015-09-28T20:36:37+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "cd378a50-f1c7-4a1f-a99d-80436806feea",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/04019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04019.jpg"
+            "imagesrc": "/images/cards/en/04019.jpg"
         },
         {
             "last-modified": "2015-09-28T20:36:53+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "ff26cca7-830f-440a-90cd-08e32c629d7e",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/04020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04020.jpg"
+            "imagesrc": "/images/cards/en/04020.jpg"
         },
         {
             "last-modified": "2015-09-28T20:37:09+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "25787651-53b5-456e-bb42-8f38fd7b3caf",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/04021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/04021.jpg"
+            "imagesrc": "/images/cards/en/04021.jpg"
         }
     ]
 }

--- a/packs/FF.json
+++ b/packs/FF.json
@@ -39,7 +39,7 @@
             "octgnid": "d5ed8e5d-c9f9-4e9e-8bc9-48da7c938045",
             "value": "",
             "url": "https://dtdb.co/en/card/05001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05001.jpg"
+            "imagesrc": "/images/cards/en/05001.jpg"
         },
         {
             "last-modified": "2015-09-29T20:28:32+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "b6cfa257-5898-4f1a-968c-8f36956f499b",
             "value": "",
             "url": "https://dtdb.co/en/card/05002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05002.jpg"
+            "imagesrc": "/images/cards/en/05002.jpg"
         },
         {
             "last-modified": "2015-09-29T20:28:50+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "6db17405-bbd3-4c0c-b00f-b89991925291",
             "value": "",
             "url": "https://dtdb.co/en/card/05003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05003.jpg"
+            "imagesrc": "/images/cards/en/05003.jpg"
         },
         {
             "last-modified": "2015-09-29T20:29:17+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "5669e37c-fab7-4954-acb8-7f841ca7a762",
             "value": "",
             "url": "https://dtdb.co/en/card/05004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05004.jpg"
+            "imagesrc": "/images/cards/en/05004.jpg"
         },
         {
             "last-modified": "2015-09-29T20:29:53+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "6a4d1a94-7e29-465e-9a41-f78389ef49cf",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/05005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05005.jpg"
+            "imagesrc": "/images/cards/en/05005.jpg"
         },
         {
             "last-modified": "2015-09-29T20:30:16+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "aba65d32-3cb2-4677-b000-f4b905c4a16e",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/05006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05006.jpg"
+            "imagesrc": "/images/cards/en/05006.jpg"
         },
         {
             "last-modified": "2015-10-03T12:07:47+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "1ff5d90e-e801-4199-80bc-7313bc8cf99e",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/05007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05007.jpg"
+            "imagesrc": "/images/cards/en/05007.jpg"
         },
         {
             "last-modified": "2015-09-29T20:31:00+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "da32c302-02de-4a5b-89c4-8227dba9f3c7",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/05008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05008.jpg"
+            "imagesrc": "/images/cards/en/05008.jpg"
         },
         {
             "last-modified": "2015-09-29T20:31:30+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "cdfcd050-f5f1-40df-a10a-4039fb74935d",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/05009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05009.jpg"
+            "imagesrc": "/images/cards/en/05009.jpg"
         },
         {
             "last-modified": "2015-09-29T20:31:52+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "5167ca6e-657d-4d96-a72b-247b2298abf9",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/05010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05010.jpg"
+            "imagesrc": "/images/cards/en/05010.jpg"
         },
         {
             "last-modified": "2015-09-29T20:33:06+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "5a2cbed4-9d68-4c5d-acb6-93e2d25b268f",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/05011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05011.jpg"
+            "imagesrc": "/images/cards/en/05011.jpg"
         },
         {
             "last-modified": "2015-10-03T12:08:22+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "7d2d0bb3-f477-4076-8739-9479911b95a6",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/05012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05012.jpg"
+            "imagesrc": "/images/cards/en/05012.jpg"
         },
         {
             "last-modified": "2015-09-29T20:33:42+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "a2b5195e-4d31-41e9-8407-c40ce54cc334",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/05013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05013.jpg"
+            "imagesrc": "/images/cards/en/05013.jpg"
         },
         {
             "last-modified": "2015-09-29T20:34:12+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "dfb10d22-9e8f-4031-9249-50cd13ee7203",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/05014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05014.jpg"
+            "imagesrc": "/images/cards/en/05014.jpg"
         },
         {
             "last-modified": "2015-09-29T20:34:26+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "9937f528-6b65-4625-85d8-05a51af488d2",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/05015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05015.jpg"
+            "imagesrc": "/images/cards/en/05015.jpg"
         },
         {
             "last-modified": "2015-09-29T20:34:39+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "933eccf1-ad0d-4153-8381-a23c6de97a60",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/05016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05016.jpg"
+            "imagesrc": "/images/cards/en/05016.jpg"
         },
         {
             "last-modified": "2015-09-29T20:35:07+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "2923cd38-686c-4ab3-8996-94fd989bff9b",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/05017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05017.jpg"
+            "imagesrc": "/images/cards/en/05017.jpg"
         },
         {
             "last-modified": "2015-09-29T20:35:22+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "38b1ca04-c236-4d51-80dd-1c283957095e",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/05018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05018.jpg"
+            "imagesrc": "/images/cards/en/05018.jpg"
         },
         {
             "last-modified": "2015-09-29T20:36:09+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "35a3cffb-6a57-4a90-ab93-63f519910c99",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/05019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05019.jpg"
+            "imagesrc": "/images/cards/en/05019.jpg"
         },
         {
             "last-modified": "2015-10-03T12:08:53+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "1b2b9609-05a4-4aed-ab98-06ddf6dbe400",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/05020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05020.jpg"
+            "imagesrc": "/images/cards/en/05020.jpg"
         },
         {
             "last-modified": "2015-10-03T12:09:16+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "c5bf5c92-9d15-42fa-aacf-67163913518a",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/05021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05021.jpg"
+            "imagesrc": "/images/cards/en/05021.jpg"
         },
         {
             "last-modified": "2015-04-10T06:49:36+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "4bd2615b-6a1b-465e-a16d-923fd77ee443",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/05022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05022.jpg"
+            "imagesrc": "/images/cards/en/05022.jpg"
         },
         {
             "last-modified": "2015-09-29T20:37:46+02:00",
@@ -765,7 +765,7 @@
             "octgnid": "e77f6e44-7900-4d0e-b370-defa7cd6796d",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/05023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05023.jpg"
+            "imagesrc": "/images/cards/en/05023.jpg"
         },
         {
             "last-modified": "2015-04-10T06:49:36+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "4827d51e-458b-4945-8242-ddfd2fdd9821",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/05024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05024.jpg"
+            "imagesrc": "/images/cards/en/05024.jpg"
         },
         {
             "last-modified": "2015-10-10T16:34:00+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "a8546fc6-be73-41eb-b33a-62b2b8158696",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/05025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05025.jpg"
+            "imagesrc": "/images/cards/en/05025.jpg"
         },
         {
             "last-modified": "2015-10-03T12:10:06+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "bc4af72b-b53c-44ef-858b-04d33e1e6a4b",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/05026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05026.jpg"
+            "imagesrc": "/images/cards/en/05026.jpg"
         },
         {
             "last-modified": "2015-10-03T12:11:27+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "a0c826bd-311f-4918-aeeb-9c2a14b176c3",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/05027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05027.jpg"
+            "imagesrc": "/images/cards/en/05027.jpg"
         },
         {
             "last-modified": "2015-09-29T20:40:29+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "9b76ed8e-e25b-47a5-b8d7-e7c020e7a230",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/05028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05028.jpg"
+            "imagesrc": "/images/cards/en/05028.jpg"
         },
         {
             "last-modified": "2015-09-29T20:40:51+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "8d8fa80c-580b-44b3-8e66-b89392299200",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/05029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05029.jpg"
+            "imagesrc": "/images/cards/en/05029.jpg"
         },
         {
             "last-modified": "2015-09-29T20:41:07+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "a806a33f-8bb2-4a47-9bdc-f3dc7d2058ea",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/05030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05030.jpg"
+            "imagesrc": "/images/cards/en/05030.jpg"
         },
         {
             "last-modified": "2015-09-29T20:41:24+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "c5c2fed5-010f-4ece-a5e2-2cf200695064",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/05031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05031.jpg"
+            "imagesrc": "/images/cards/en/05031.jpg"
         },
         {
             "last-modified": "2015-09-29T20:42:01+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "c7d43986-30a5-46ac-99a3-01d94ceda540",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/05032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05032.jpg"
+            "imagesrc": "/images/cards/en/05032.jpg"
         },
         {
             "last-modified": "2015-09-29T20:42:35+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "77df4257-28e1-4865-8d20-5e0087fcd8d5",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/05033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05033.jpg"
+            "imagesrc": "/images/cards/en/05033.jpg"
         },
         {
             "last-modified": "2015-09-29T20:43:01+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "4eba0738-ddf4-4bce-9c3c-ecb06d3381ff",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/05034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05034.jpg"
+            "imagesrc": "/images/cards/en/05034.jpg"
         },
         {
             "last-modified": "2015-09-29T20:43:23+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "0b1ae36c-6359-4871-b34b-16808e639243",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/05035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05035.jpg"
+            "imagesrc": "/images/cards/en/05035.jpg"
         },
         {
             "last-modified": "2015-09-29T20:43:40+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "adf4a674-bc8a-4158-ae1a-cb7224fbb850",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/05036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05036.jpg"
+            "imagesrc": "/images/cards/en/05036.jpg"
         },
         {
             "last-modified": "2015-09-29T20:43:57+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "07c1a52a-fcdc-4775-b42c-f352465942da",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/05037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05037.jpg"
+            "imagesrc": "/images/cards/en/05037.jpg"
         },
         {
             "last-modified": "2015-10-03T12:11:53+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "546a4107-75f3-49f6-84a1-4396ca3c61c1",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/05038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05038.jpg"
+            "imagesrc": "/images/cards/en/05038.jpg"
         },
         {
             "last-modified": "2015-09-29T20:44:43+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "e12da368-0c9a-435b-91e7-e08378a6363c",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/05039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05039.jpg"
+            "imagesrc": "/images/cards/en/05039.jpg"
         },
         {
             "last-modified": "2015-09-29T20:44:58+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "c27e60e9-8450-4e6e-9c2e-73d19caec7c1",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/05040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/05040.jpg"
+            "imagesrc": "/images/cards/en/05040.jpg"
         }
     ]
 }

--- a/packs/FJ.json
+++ b/packs/FJ.json
@@ -39,7 +39,7 @@
             "octgnid": "2fab82a8-2a4d-4545-855a-9d1ea011a8c9",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/06001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06001.jpg"
+            "imagesrc": "/images/cards/en/06001.jpg"
         },
         {
             "last-modified": "2015-10-02T20:06:43+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "7d58d611-07a2-41e6-ad4d-fc51cc794847",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/06002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06002.jpg"
+            "imagesrc": "/images/cards/en/06002.jpg"
         },
         {
             "last-modified": "2015-10-02T20:07:04+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "7b51deb6-fb5f-4624-8473-32533ec7309c",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/06003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06003.jpg"
+            "imagesrc": "/images/cards/en/06003.jpg"
         },
         {
             "last-modified": "2015-10-02T20:07:25+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "e341450b-9b41-4ae1-a1aa-fa50ac743f90",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/06004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06004.jpg"
+            "imagesrc": "/images/cards/en/06004.jpg"
         },
         {
             "last-modified": "2015-10-02T20:07:48+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "a44b9e09-8941-4e30-ab0e-c2171949e8d5",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/06005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06005.jpg"
+            "imagesrc": "/images/cards/en/06005.jpg"
         },
         {
             "last-modified": "2020-02-08T23:19:48+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "bc36b880-9e3c-458b-8ef4-9730a926bf38",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/06006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06006.jpg"
+            "imagesrc": "/images/cards/en/06006.jpg"
         },
         {
             "last-modified": "2015-10-02T20:08:47+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "135a9ce8-4e8b-463a-9fcc-23f0168e4762",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/06007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06007.jpg"
+            "imagesrc": "/images/cards/en/06007.jpg"
         },
         {
             "last-modified": "2015-10-02T20:09:07+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "9440378f-dd04-426c-9696-f24e0789e528",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/06008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06008.jpg"
+            "imagesrc": "/images/cards/en/06008.jpg"
         },
         {
             "last-modified": "2015-10-02T20:09:48+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "fde8c18b-58e2-40ab-b407-fe42a4fe549d",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/06009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06009.jpg"
+            "imagesrc": "/images/cards/en/06009.jpg"
         },
         {
             "last-modified": "2015-10-02T20:10:39+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "18df456c-38ac-4e2b-b4ab-f309849d2cb7",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/06010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06010.jpg"
+            "imagesrc": "/images/cards/en/06010.jpg"
         },
         {
             "last-modified": "2015-10-02T20:11:10+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "edc1d27d-2cd3-494f-90d8-36f9edfdbb61",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/06011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06011.jpg"
+            "imagesrc": "/images/cards/en/06011.jpg"
         },
         {
             "last-modified": "2015-10-02T20:11:43+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "438f980e-0981-473e-a9c5-0a8d07ee4634",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/06012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06012.jpg"
+            "imagesrc": "/images/cards/en/06012.jpg"
         },
         {
             "last-modified": "2015-10-02T20:12:10+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "caff0709-27f0-4596-8cbb-ad1b403a2368",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/06013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06013.jpg"
+            "imagesrc": "/images/cards/en/06013.jpg"
         },
         {
             "last-modified": "2015-10-02T20:12:37+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "4e59a712-6f55-4703-a420-a1f62b483afa",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/06014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06014.jpg"
+            "imagesrc": "/images/cards/en/06014.jpg"
         },
         {
             "last-modified": "2015-10-02T20:12:57+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "c5a6c2ba-866e-4854-bbaf-4e3fd6ea49de",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/06015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06015.jpg"
+            "imagesrc": "/images/cards/en/06015.jpg"
         },
         {
             "last-modified": "2015-05-11T13:28:16+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "bb4aad56-6d02-4088-9f20-f64c571f593b",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/06016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06016.jpg"
+            "imagesrc": "/images/cards/en/06016.jpg"
         },
         {
             "last-modified": "2015-10-02T20:13:46+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "51b83721-61e5-42bc-be9e-8b671f0668d4",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/06017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06017.jpg"
+            "imagesrc": "/images/cards/en/06017.jpg"
         },
         {
             "last-modified": "2015-10-02T20:14:02+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "ae0d585d-25e0-4495-8757-71ef0efffb0e",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/06018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06018.jpg"
+            "imagesrc": "/images/cards/en/06018.jpg"
         },
         {
             "last-modified": "2015-10-02T20:14:32+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "1e6f4bb8-762f-4e61-9f19-b3585c0f5186",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/06019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06019.jpg"
+            "imagesrc": "/images/cards/en/06019.jpg"
         },
         {
             "last-modified": "2015-10-02T20:15:14+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "f36622a2-667f-43bc-ac16-0f8c8dabec00",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/06020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06020.jpg"
+            "imagesrc": "/images/cards/en/06020.jpg"
         },
         {
             "last-modified": "2015-10-02T20:15:41+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "3e1d8cfb-03b1-433a-a7ae-b12f124fb7ef",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/06021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/06021.jpg"
+            "imagesrc": "/images/cards/en/06021.jpg"
         }
     ]
 }

--- a/packs/FP.json
+++ b/packs/FP.json
@@ -39,7 +39,7 @@
             "octgnid": "bc2f230e-1c4a-47fe-ab97-31a58112e473",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/12001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12001.jpg"
+            "imagesrc": "/images/cards/en/12001.jpg"
         },
         {
             "last-modified": "2015-12-30T14:41:06+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "1d283fb4-9fe2-4143-83e2-b6080149df3f",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/12002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12002.jpg"
+            "imagesrc": "/images/cards/en/12002.jpg"
         },
         {
             "last-modified": "2015-12-30T14:42:55+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "7f2d6abb-5b50-4d3c-8a2d-aeb447ea5fbd",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/12003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12003.jpg"
+            "imagesrc": "/images/cards/en/12003.jpg"
         },
         {
             "last-modified": "2015-12-30T14:46:47+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "45f31939-bdaf-49ee-850f-b08f5c809dc0",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/12004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12004.jpg"
+            "imagesrc": "/images/cards/en/12004.jpg"
         },
         {
             "last-modified": "2015-12-30T14:48:44+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "f1d866bc-8056-4cc8-976a-ee76afca5054",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/12005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12005.jpg"
+            "imagesrc": "/images/cards/en/12005.jpg"
         },
         {
             "last-modified": "2015-12-30T14:55:52+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "644870b4-541c-4824-af19-3e9a5cd28264",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/12006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12006.jpg"
+            "imagesrc": "/images/cards/en/12006.jpg"
         },
         {
             "last-modified": "2015-12-30T15:03:06+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "16d4df2b-4494-4e65-b910-2c35e07d604c",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/12007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12007.jpg"
+            "imagesrc": "/images/cards/en/12007.jpg"
         },
         {
             "last-modified": "2015-12-30T15:04:42+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "43abee45-ec1d-4e5f-8997-e8501d66ed5b",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/12008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12008.jpg"
+            "imagesrc": "/images/cards/en/12008.jpg"
         },
         {
             "last-modified": "2015-12-30T15:06:14+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "662dd66d-9cb9-48f6-84bd-4496b3484d01",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/12009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12009.jpg"
+            "imagesrc": "/images/cards/en/12009.jpg"
         },
         {
             "last-modified": "2015-12-30T15:07:46+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "41a8c1e5-03e8-427e-a1f2-ffc59dbc420b",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/12010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12010.jpg"
+            "imagesrc": "/images/cards/en/12010.jpg"
         },
         {
             "last-modified": "2015-12-30T15:11:41+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "d3a57ce1-7abd-45b0-82d7-fa0d6324a91d",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/12011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12011.jpg"
+            "imagesrc": "/images/cards/en/12011.jpg"
         },
         {
             "last-modified": "2015-12-30T15:13:21+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "19bdb26b-0853-4520-9f72-71d7e4ab6c1d",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/12012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12012.jpg"
+            "imagesrc": "/images/cards/en/12012.jpg"
         },
         {
             "last-modified": "2015-12-30T15:15:25+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "288545a8-9c7b-4e31-ad00-c97910b19b17",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/12013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12013.jpg"
+            "imagesrc": "/images/cards/en/12013.jpg"
         },
         {
             "last-modified": "2015-12-30T15:16:49+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "0ed71726-f276-419e-b037-17eb62294489",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/12014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12014.jpg"
+            "imagesrc": "/images/cards/en/12014.jpg"
         },
         {
             "last-modified": "2015-12-30T15:18:42+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "aa1c1ffa-db99-464b-849d-5cb6264245b7",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/12015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12015.jpg"
+            "imagesrc": "/images/cards/en/12015.jpg"
         },
         {
             "last-modified": "2015-12-30T15:20:12+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "fcac7bbf-dd62-43de-8ade-8ba9893a986f",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/12016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12016.jpg"
+            "imagesrc": "/images/cards/en/12016.jpg"
         },
         {
             "last-modified": "2015-12-30T15:21:34+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "dd9cbe71-952b-4b3f-8b53-afa6144488ac",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/12017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12017.jpg"
+            "imagesrc": "/images/cards/en/12017.jpg"
         },
         {
             "last-modified": "2017-11-05T03:26:25+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "e530bd2e-0fae-4f00-a522-ba5801904a44",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/12018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12018.jpg"
+            "imagesrc": "/images/cards/en/12018.jpg"
         },
         {
             "last-modified": "2015-12-30T15:24:30+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "24bb7502-06a2-4871-9ede-fe28d7539eec",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/12019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12019.jpg"
+            "imagesrc": "/images/cards/en/12019.jpg"
         },
         {
             "last-modified": "2015-12-30T15:25:28+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "27d7356b-3c4d-4b2d-9c23-28aca5cc9c81",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/12020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12020.jpg"
+            "imagesrc": "/images/cards/en/12020.jpg"
         },
         {
             "last-modified": "2015-12-30T15:26:52+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "31ac9e9d-ff78-4f42-a8c1-9014c7df461e",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/12021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/12021.jpg"
+            "imagesrc": "/images/cards/en/12021.jpg"
         }
     ]
 }

--- a/packs/GT.json
+++ b/packs/GT.json
@@ -39,7 +39,7 @@
             "octgnid": "8463332e-61fb-4744-b6cb-89fbcec18bdd",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/14001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14001.jpg"
+            "imagesrc": "/images/cards/en/14001.jpg"
         },
         {
             "last-modified": "2016-03-28T13:48:29+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "c2d7e814-dddf-4f21-9315-d2d5993da004",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/14002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14002.jpg"
+            "imagesrc": "/images/cards/en/14002.jpg"
         },
         {
             "last-modified": "2016-03-28T13:49:52+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "a8b44597-b8b4-4a8a-b077-d6f0495248d7",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/14003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14003.jpg"
+            "imagesrc": "/images/cards/en/14003.jpg"
         },
         {
             "last-modified": "2016-03-28T13:51:41+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "f21a80e4-27f0-4c87-a44e-64661765a000",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/14004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14004.jpg"
+            "imagesrc": "/images/cards/en/14004.jpg"
         },
         {
             "last-modified": "2016-03-28T13:55:57+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "62a29361-d2d6-4934-ac70-916435475094",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/14005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14005.jpg"
+            "imagesrc": "/images/cards/en/14005.jpg"
         },
         {
             "last-modified": "2016-05-12T20:21:35+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "7ab8a00e-d449-42ec-ae60-3dff03151dce",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/14006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14006.jpg"
+            "imagesrc": "/images/cards/en/14006.jpg"
         },
         {
             "last-modified": "2016-03-28T14:00:53+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "3c6ad64f-f716-4ee8-80db-f13602745d44",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/14007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14007.jpg"
+            "imagesrc": "/images/cards/en/14007.jpg"
         },
         {
             "last-modified": "2016-05-12T20:25:52+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "991495ee-2b58-4e7f-92d0-11ffaca1cff5",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/14008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14008.jpg"
+            "imagesrc": "/images/cards/en/14008.jpg"
         },
         {
             "last-modified": "2016-03-28T14:04:04+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "f9f258f4-dd3b-43c8-9081-79939b5b76b0",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/14009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14009.jpg"
+            "imagesrc": "/images/cards/en/14009.jpg"
         },
         {
             "last-modified": "2016-03-28T14:05:42+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "6bbd7290-5c98-4378-b581-0c044b96860a",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/14010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14010.jpg"
+            "imagesrc": "/images/cards/en/14010.jpg"
         },
         {
             "last-modified": "2016-03-28T14:12:27+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "8bb9b173-38ce-4b99-8874-3197a596b17e",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/14011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14011.jpg"
+            "imagesrc": "/images/cards/en/14011.jpg"
         },
         {
             "last-modified": "2016-03-28T14:14:20+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "cde1ec30-fedd-46de-af9b-110856d0f1c7",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/14012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14012.jpg"
+            "imagesrc": "/images/cards/en/14012.jpg"
         },
         {
             "last-modified": "2016-03-28T14:15:54+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "22df7ba7-5a3e-45de-b12a-a6c672ad6ccf",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/14013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14013.jpg"
+            "imagesrc": "/images/cards/en/14013.jpg"
         },
         {
             "last-modified": "2016-03-28T14:18:21+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "74d2d9ea-bcc7-4c61-b4a1-0a54856501dc",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/14014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14014.jpg"
+            "imagesrc": "/images/cards/en/14014.jpg"
         },
         {
             "last-modified": "2016-03-28T14:20:31+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "aacdc6a0-f543-4cc2-8370-b2bec8eccc6a",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/14015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14015.jpg"
+            "imagesrc": "/images/cards/en/14015.jpg"
         },
         {
             "last-modified": "2016-03-28T14:22:10+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "98487814-4411-4701-85e6-3c45340679d0",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/14016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14016.jpg"
+            "imagesrc": "/images/cards/en/14016.jpg"
         },
         {
             "last-modified": "2016-03-28T14:24:40+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "e734385a-eb43-4dd0-931d-16b99750de17",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/14017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14017.jpg"
+            "imagesrc": "/images/cards/en/14017.jpg"
         },
         {
             "last-modified": "2016-03-28T14:26:16+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "97babd64-ce97-4996-a4a5-f6782660c895",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/14018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14018.jpg"
+            "imagesrc": "/images/cards/en/14018.jpg"
         },
         {
             "last-modified": "2016-04-13T14:53:29+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "df42a53c-8fab-4603-9294-f51d4a44e95e",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/14019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14019.jpg"
+            "imagesrc": "/images/cards/en/14019.jpg"
         },
         {
             "last-modified": "2016-03-28T14:30:15+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "f7be47f3-b72b-4739-8391-e7d718868b90",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/14020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14020.jpg"
+            "imagesrc": "/images/cards/en/14020.jpg"
         },
         {
             "last-modified": "2016-03-28T14:31:22+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "3e3fff09-9401-46d2-ab8e-cfce77ddde58",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/14021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14021.jpg"
+            "imagesrc": "/images/cards/en/14021.jpg"
         },
         {
             "last-modified": "2016-03-28T14:32:42+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "e3efb184-9dc0-4c4f-9b07-b7c01c66a424",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/14022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14022.jpg"
+            "imagesrc": "/images/cards/en/14022.jpg"
         },
         {
             "last-modified": "2017-11-08T03:13:43+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "63df2636-a2b4-4470-9b3f-596c2e311dd1",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/14023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14023.jpg"
+            "imagesrc": "/images/cards/en/14023.jpg"
         },
         {
             "last-modified": "2016-03-28T14:35:22+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "4b68dd9b-fb40-4912-8ff6-d7de771861dd",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/14024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14024.jpg"
+            "imagesrc": "/images/cards/en/14024.jpg"
         },
         {
             "last-modified": "2016-03-28T14:37:13+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "54cd83d3-4735-4948-9a49-9570710da531",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/14025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14025.jpg"
+            "imagesrc": "/images/cards/en/14025.jpg"
         },
         {
             "last-modified": "2016-03-28T14:39:12+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "ccc98846-eea5-4568-9726-2f86d9b90896",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/14026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14026.jpg"
+            "imagesrc": "/images/cards/en/14026.jpg"
         },
         {
             "last-modified": "2016-03-28T14:41:27+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "b2371c67-bdd2-4ba6-b236-86a551e0f2c1",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/14027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14027.jpg"
+            "imagesrc": "/images/cards/en/14027.jpg"
         },
         {
             "last-modified": "2016-03-28T14:42:48+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "ed8fda6f-0cee-4d73-9af0-159fbb3db4e0",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/14028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14028.jpg"
+            "imagesrc": "/images/cards/en/14028.jpg"
         },
         {
             "last-modified": "2016-03-28T14:44:06+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "28b4125d-61a9-4714-870c-2f27e4872e9f",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/14029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14029.jpg"
+            "imagesrc": "/images/cards/en/14029.jpg"
         },
         {
             "last-modified": "2016-03-28T14:45:33+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "27ddc945-bfc5-4dd9-84d8-d6bc44c904ae",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/14030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14030.jpg"
+            "imagesrc": "/images/cards/en/14030.jpg"
         },
         {
             "last-modified": "2016-03-28T14:46:45+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "b1db504d-513e-4ce8-8113-c64ded1b0ad5",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/14031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14031.jpg"
+            "imagesrc": "/images/cards/en/14031.jpg"
         },
         {
             "last-modified": "2016-03-28T14:47:46+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "61e47afb-cb64-46b5-86ae-893590b84139",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/14032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14032.jpg"
+            "imagesrc": "/images/cards/en/14032.jpg"
         },
         {
             "last-modified": "2016-03-28T14:49:08+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "2c318b93-e6b8-422d-b062-baecfc06e62a",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/14033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14033.jpg"
+            "imagesrc": "/images/cards/en/14033.jpg"
         },
         {
             "last-modified": "2016-03-28T14:50:38+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "4964e22f-04f8-4d72-b70c-9b1c8d85a53a",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/14034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14034.jpg"
+            "imagesrc": "/images/cards/en/14034.jpg"
         },
         {
             "last-modified": "2016-03-28T14:51:50+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "083b92c1-bf91-4d5b-95e0-23a72bd0d05a",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/14035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14035.jpg"
+            "imagesrc": "/images/cards/en/14035.jpg"
         },
         {
             "last-modified": "2016-03-28T14:52:55+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "c5d383fa-b1e7-4135-bb1a-a530b9f8338d",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/14036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14036.jpg"
+            "imagesrc": "/images/cards/en/14036.jpg"
         },
         {
             "last-modified": "2016-03-28T14:54:18+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "92a85b68-c791-46ac-8515-22379ea67e99",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/14037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14037.jpg"
+            "imagesrc": "/images/cards/en/14037.jpg"
         },
         {
             "last-modified": "2016-03-28T14:55:58+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "e27b4a68-2a7b-48e9-9dae-a42d02f8a66f",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/14038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14038.jpg"
+            "imagesrc": "/images/cards/en/14038.jpg"
         },
         {
             "last-modified": "2016-03-28T14:57:26+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "38c663b2-e6f8-4135-83d0-46122e5be7d6",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/14039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14039.jpg"
+            "imagesrc": "/images/cards/en/14039.jpg"
         },
         {
             "last-modified": "2016-03-28T14:59:08+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "e2e638ff-27cb-4704-b324-bd318dc9170a",
             "value": "",
             "url": "https://dtdb.co/en/card/14040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14040.jpg"
+            "imagesrc": "/images/cards/en/14040.jpg"
         },
         {
             "last-modified": "2016-05-12T20:23:52+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "57039087-1868-4430-a94b-fb7eedeb04a5",
             "value": "",
             "url": "https://dtdb.co/en/card/14041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/14041.jpg"
+            "imagesrc": "/images/cards/en/14041.jpg"
         }
     ]
 }

--- a/packs/HCWM.json
+++ b/packs/HCWM.json
@@ -39,7 +39,7 @@
             "octgnid": "ac361a31-dd5f-4fca-91fd-67a43c202ae3",
             "value": "",
             "url": "https://dtdb.co/en/card/22001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22001.jpg"
+            "imagesrc": "/images/cards/en/22001.jpg"
         },
         {
             "last-modified": "2019-12-16T03:00:21+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "d8173547-1e8d-43b1-9433-f99f0017115f",
             "value": "",
             "url": "https://dtdb.co/en/card/22002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22002.jpg"
+            "imagesrc": "/images/cards/en/22002.jpg"
         },
         {
             "last-modified": "2019-12-16T03:01:44+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "dff6d14c-e693-4d52-b6c7-edbdef001e6a",
             "value": "",
             "url": "https://dtdb.co/en/card/22003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22003.jpg"
+            "imagesrc": "/images/cards/en/22003.jpg"
         },
         {
             "last-modified": "2020-02-08T20:34:48+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "30871624-02ac-0d3e-0a05-4a2860a9fabf",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/22004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22004.jpg"
+            "imagesrc": "/images/cards/en/22004.jpg"
         },
         {
             "last-modified": "2019-12-16T03:05:33+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "77f21d94-03ca-8e72-ce20-ef74ef1395f9",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/22005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22005.jpg"
+            "imagesrc": "/images/cards/en/22005.jpg"
         },
         {
             "last-modified": "2020-02-08T20:36:57+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "7103434e-2e84-f631-f0e1-c31f63767aa9",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/22006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22006.jpg"
+            "imagesrc": "/images/cards/en/22006.jpg"
         },
         {
             "last-modified": "2020-02-08T20:39:24+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "8972e73e-3ce9-c28f-f18a-d86c28ff4feb",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/22007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22007.jpg"
+            "imagesrc": "/images/cards/en/22007.jpg"
         },
         {
             "last-modified": "2020-02-08T20:40:56+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "3079af53-b91d-a4a1-57ef-41c4ce59bdc8",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/22008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22008.jpg"
+            "imagesrc": "/images/cards/en/22008.jpg"
         },
         {
             "last-modified": "2020-02-08T20:42:14+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "902822a9-9591-0a5f-15f0-3858408570bd",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/22009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22009.jpg"
+            "imagesrc": "/images/cards/en/22009.jpg"
         },
         {
             "last-modified": "2020-02-08T20:43:31+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "c48079e7-60b1-ddb8-1729-404fd10edcdc",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/22010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22010.jpg"
+            "imagesrc": "/images/cards/en/22010.jpg"
         },
         {
             "last-modified": "2020-02-11T01:50:00+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "aea80f2c-e226-ca1c-59fe-e01fd4a65b97",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/22011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22011.jpg"
+            "imagesrc": "/images/cards/en/22011.jpg"
         },
         {
             "last-modified": "2020-02-08T20:52:30+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "38a6347d-ad73-9cc0-d7e5-557d9c8d7158",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/22012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22012.jpg"
+            "imagesrc": "/images/cards/en/22012.jpg"
         },
         {
             "last-modified": "2020-02-08T20:53:50+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "c59a067e-d293-9403-cb80-49106ec4e38d",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/22013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22013.jpg"
+            "imagesrc": "/images/cards/en/22013.jpg"
         },
         {
             "last-modified": "2019-12-16T03:17:35+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "c4c882aa-f96f-b6bb-830a-6482099009fa",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/22014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22014.jpg"
+            "imagesrc": "/images/cards/en/22014.jpg"
         },
         {
             "last-modified": "2020-02-08T20:55:39+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "7ca0b92e-4508-8535-20f1-4796ae094c2b",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/22015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22015.jpg"
+            "imagesrc": "/images/cards/en/22015.jpg"
         },
         {
             "last-modified": "2019-12-16T03:19:04+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "707282a8-c871-c6f4-48dd-12ba2dc88fc2",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/22016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22016.jpg"
+            "imagesrc": "/images/cards/en/22016.jpg"
         },
         {
             "last-modified": "2020-02-08T20:57:31+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "ebfb026f-eb45-02c8-0bbd-0c2b5fa5cfdd",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/22017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22017.jpg"
+            "imagesrc": "/images/cards/en/22017.jpg"
         },
         {
             "last-modified": "2020-02-08T20:58:42+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "e622aa3b-c00e-e807-9e58-cb9a2932d34e",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/22018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22018.jpg"
+            "imagesrc": "/images/cards/en/22018.jpg"
         },
         {
             "last-modified": "2020-02-08T21:01:10+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "51e08e8f-12b8-9897-c380-5bfbb5bcde96",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/22019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22019.jpg"
+            "imagesrc": "/images/cards/en/22019.jpg"
         },
         {
             "last-modified": "2020-02-12T21:10:34+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "085d6a20-5cbd-6b09-43bc-68720e213848",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/22020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22020.jpg"
+            "imagesrc": "/images/cards/en/22020.jpg"
         },
         {
             "last-modified": "2020-02-08T21:03:12+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "5b6b6aa0-1824-60a5-98ef-cd2fd4edadb0",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/22021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22021.jpg"
+            "imagesrc": "/images/cards/en/22021.jpg"
         },
         {
             "last-modified": "2019-12-16T03:22:44+01:00",
@@ -732,7 +732,7 @@
             "octgnid": "6ddde887-06b9-a3d4-2b93-f02cd2183ea8",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/22022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22022.jpg"
+            "imagesrc": "/images/cards/en/22022.jpg"
         },
         {
             "last-modified": "2020-02-08T22:05:36+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "25ea3f58-99ad-3df5-225b-96ae4e88eccb",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/22023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22023.jpg"
+            "imagesrc": "/images/cards/en/22023.jpg"
         },
         {
             "last-modified": "2020-02-08T22:07:52+01:00",
@@ -798,7 +798,7 @@
             "octgnid": "0debb6d1-05fa-83ee-ef73-e0f0b21d696e",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/22024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22024.jpg"
+            "imagesrc": "/images/cards/en/22024.jpg"
         },
         {
             "last-modified": "2020-02-08T23:17:09+01:00",
@@ -831,7 +831,7 @@
             "octgnid": "f5cfecaf-af17-e447-2223-86a8e393e1fd",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/22025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22025.jpg"
+            "imagesrc": "/images/cards/en/22025.jpg"
         },
         {
             "last-modified": "2020-02-08T22:29:08+01:00",
@@ -864,7 +864,7 @@
             "octgnid": "4420ecb6-c2db-7c32-47cd-ea28f8c42543",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/22026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22026.jpg"
+            "imagesrc": "/images/cards/en/22026.jpg"
         },
         {
             "last-modified": "2020-02-08T22:30:34+01:00",
@@ -897,7 +897,7 @@
             "octgnid": "8c7fd924-8962-daee-9631-2ee5e61491af",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/22027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22027.jpg"
+            "imagesrc": "/images/cards/en/22027.jpg"
         },
         {
             "last-modified": "2020-02-08T22:31:55+01:00",
@@ -930,7 +930,7 @@
             "octgnid": "2246467a-1e5c-4913-9d9b-9e3e795c5177",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/22028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22028.jpg"
+            "imagesrc": "/images/cards/en/22028.jpg"
         },
         {
             "last-modified": "2020-02-08T22:36:17+01:00",
@@ -963,7 +963,7 @@
             "octgnid": "ba276f31-01f8-4845-af82-e12fab75eed4",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/22029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22029.jpg"
+            "imagesrc": "/images/cards/en/22029.jpg"
         },
         {
             "last-modified": "2020-02-08T22:37:26+01:00",
@@ -996,7 +996,7 @@
             "octgnid": "f37f74d8-af99-13aa-db56-99da98c2f350",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/22030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22030.jpg"
+            "imagesrc": "/images/cards/en/22030.jpg"
         },
         {
             "last-modified": "2020-02-08T22:39:00+01:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "d58589b0-6da3-4dc6-afb3-5956e24a0cc4",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/22031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22031.jpg"
+            "imagesrc": "/images/cards/en/22031.jpg"
         },
         {
             "last-modified": "2020-02-08T22:45:07+01:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "9b3e329b-7483-427f-965c-b599730853f1",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/22032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22032.jpg"
+            "imagesrc": "/images/cards/en/22032.jpg"
         },
         {
             "last-modified": "2020-11-30T22:20:53+01:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "6b0a155b-0bc0-4a05-a3f0-9e82eeda84cd",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/22033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22033.jpg"
+            "imagesrc": "/images/cards/en/22033.jpg"
         },
         {
             "last-modified": "2019-12-16T03:29:24+01:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "291194ef-0102-4843-a105-f5fec8bfb5e3",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/22034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22034.jpg"
+            "imagesrc": "/images/cards/en/22034.jpg"
         },
         {
             "last-modified": "2020-02-08T22:48:45+01:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "c23fb989-758e-4065-8388-c41e9bc8a7ae",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/22035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22035.jpg"
+            "imagesrc": "/images/cards/en/22035.jpg"
         },
         {
             "last-modified": "2020-02-08T22:50:28+01:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "b4a19ef0-c40b-45e0-bc9a-754c301630fb",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/22036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22036.jpg"
+            "imagesrc": "/images/cards/en/22036.jpg"
         },
         {
             "last-modified": "2020-02-08T22:51:14+01:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "306fa2f3-ad06-42ca-b4b4-22fcfe916018",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/22037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22037.jpg"
+            "imagesrc": "/images/cards/en/22037.jpg"
         },
         {
             "last-modified": "2020-02-08T22:52:35+01:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "3bb469af-7b3a-478f-a804-88b5b6f208c5",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/22038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22038.jpg"
+            "imagesrc": "/images/cards/en/22038.jpg"
         },
         {
             "last-modified": "2020-02-08T22:54:02+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "74bcca3c-7e81-43d7-a26d-cf98f4de2f63",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/22039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22039.jpg"
+            "imagesrc": "/images/cards/en/22039.jpg"
         },
         {
             "last-modified": "2020-02-08T22:55:20+01:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "810b1cdd-2654-4110-a219-c687369645cc",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/22040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22040.jpg"
+            "imagesrc": "/images/cards/en/22040.jpg"
         },
         {
             "last-modified": "2020-02-08T22:56:59+01:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "50c6b016-a26e-44dc-baab-0eb822d07fe5",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/22041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22041.jpg"
+            "imagesrc": "/images/cards/en/22041.jpg"
         },
         {
             "last-modified": "2020-02-08T22:58:22+01:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "d9830f56-75da-4f3f-8e53-9538c3686662",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/22042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22042.jpg"
+            "imagesrc": "/images/cards/en/22042.jpg"
         },
         {
             "last-modified": "2020-02-08T23:19:24+01:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "d53daadf-d1d4-466d-b69e-7874473c0021",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/22043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22043.jpg"
+            "imagesrc": "/images/cards/en/22043.jpg"
         },
         {
             "last-modified": "2020-02-08T22:59:55+01:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "9fac6b82-b073-483a-a47b-ebb1499d4e9e",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/22044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22044.jpg"
+            "imagesrc": "/images/cards/en/22044.jpg"
         },
         {
             "last-modified": "2020-02-08T23:01:22+01:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "d5639bec-8794-46e6-b368-9421c1670750",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/22045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22045.jpg"
+            "imagesrc": "/images/cards/en/22045.jpg"
         },
         {
             "last-modified": "2020-02-08T23:02:36+01:00",
@@ -1524,7 +1524,7 @@
             "octgnid": "31fc67cf-32e2-4bdd-9998-b30dda2ec532",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/22046",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22046.jpg"
+            "imagesrc": "/images/cards/en/22046.jpg"
         },
         {
             "last-modified": "2020-02-08T23:03:38+01:00",
@@ -1557,7 +1557,7 @@
             "octgnid": "bc5335d6-0519-45c7-b937-1afc9a20050b",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/22047",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22047.jpg"
+            "imagesrc": "/images/cards/en/22047.jpg"
         },
         {
             "last-modified": "2020-02-08T23:04:36+01:00",
@@ -1590,7 +1590,7 @@
             "octgnid": "69db55fc-fc57-46f2-805d-50a33b82db0a",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/22048",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22048.jpg"
+            "imagesrc": "/images/cards/en/22048.jpg"
         },
         {
             "last-modified": "2020-02-08T23:05:45+01:00",
@@ -1623,7 +1623,7 @@
             "octgnid": "e15cb91e-455f-4e9d-b66a-f14506011161",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/22049",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22049.jpg"
+            "imagesrc": "/images/cards/en/22049.jpg"
         },
         {
             "last-modified": "2020-02-08T23:07:07+01:00",
@@ -1656,7 +1656,7 @@
             "octgnid": "46dc8b80-1f05-4a1f-a5ea-f452c4e3dbac",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/22050",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22050.jpg"
+            "imagesrc": "/images/cards/en/22050.jpg"
         },
         {
             "last-modified": "2020-02-08T23:08:32+01:00",
@@ -1689,7 +1689,7 @@
             "octgnid": "b1d66665-08d0-4adb-9ea2-62c0aac08f4e",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/22051",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22051.jpg"
+            "imagesrc": "/images/cards/en/22051.jpg"
         },
         {
             "last-modified": "2020-02-08T23:10:03+01:00",
@@ -1722,7 +1722,7 @@
             "octgnid": "c9e9547f-9c3e-4917-8b56-7c9eb93c38df",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/22052",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22052.jpg"
+            "imagesrc": "/images/cards/en/22052.jpg"
         },
         {
             "last-modified": "2020-02-08T23:10:57+01:00",
@@ -1755,7 +1755,7 @@
             "octgnid": "8d7cc337-a3d3-4bf4-b7c5-3eb07caa1d14",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/22053",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22053.jpg"
+            "imagesrc": "/images/cards/en/22053.jpg"
         },
         {
             "last-modified": "2019-12-16T03:39:57+01:00",
@@ -1788,7 +1788,7 @@
             "octgnid": "8a8b75ce-ad2d-486a-9942-ecd2066ec92d",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/22054",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22054.jpg"
+            "imagesrc": "/images/cards/en/22054.jpg"
         },
         {
             "last-modified": "2020-02-08T23:13:28+01:00",
@@ -1821,7 +1821,7 @@
             "octgnid": "7405fcab-efba-4de4-83e9-f33364cfcb0f",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/22055",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22055.jpg"
+            "imagesrc": "/images/cards/en/22055.jpg"
         },
         {
             "last-modified": "2020-02-08T23:16:37+01:00",
@@ -1854,7 +1854,7 @@
             "octgnid": "ac4bae3a-8570-4b07-8818-4dc8626c848f",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/22056",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/22056.jpg"
+            "imagesrc": "/images/cards/en/22056.jpg"
         }
     ]
 }

--- a/packs/IOUF.json
+++ b/packs/IOUF.json
@@ -39,7 +39,7 @@
             "octgnid": "94c5b661-8f3d-46ea-975e-482ff0e2be8a",
             "value": "",
             "url": "https://dtdb.co/en/card/09001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09001.jpg"
+            "imagesrc": "/images/cards/en/09001.jpg"
         },
         {
             "last-modified": "2015-10-02T20:35:06+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "dfb469f4-efc8-46f9-84df-66f5f973c09c",
             "value": "",
             "url": "https://dtdb.co/en/card/09002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09002.jpg"
+            "imagesrc": "/images/cards/en/09002.jpg"
         },
         {
             "last-modified": "2015-10-02T20:35:21+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "942e1f7e-d6d0-4882-b8e7-68135e9d52fc",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/09003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09003.jpg"
+            "imagesrc": "/images/cards/en/09003.jpg"
         },
         {
             "last-modified": "2015-10-03T11:58:33+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "1c3b7ec1-882e-458d-9409-21e23fef5f2d",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/09004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09004.jpg"
+            "imagesrc": "/images/cards/en/09004.jpg"
         },
         {
             "last-modified": "2015-10-03T11:59:38+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "1b7d462c-4ba6-4317-904e-7efc49b4a15e",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/09005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09005.jpg"
+            "imagesrc": "/images/cards/en/09005.jpg"
         },
         {
             "last-modified": "2015-10-03T11:59:10+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "ed07deb6-3693-4ede-ae62-0f132d538211",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/09006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09006.jpg"
+            "imagesrc": "/images/cards/en/09006.jpg"
         },
         {
             "last-modified": "2015-10-02T20:37:15+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "bcc0f3cf-105d-4030-a4fc-b45d978bfc7e",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/09007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09007.jpg"
+            "imagesrc": "/images/cards/en/09007.jpg"
         },
         {
             "last-modified": "2015-07-30T23:26:20+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "48e2565e-1c96-45c8-837a-85533efc554b",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/09008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09008.jpg"
+            "imagesrc": "/images/cards/en/09008.jpg"
         },
         {
             "last-modified": "2015-10-02T20:37:44+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "910c051f-f36d-4245-88db-767d80998fc1",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/09009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09009.jpg"
+            "imagesrc": "/images/cards/en/09009.jpg"
         },
         {
             "last-modified": "2015-10-02T20:38:00+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "05b9067b-7356-4fbf-b5a7-ee96c3135b9f",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/09010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09010.jpg"
+            "imagesrc": "/images/cards/en/09010.jpg"
         },
         {
             "last-modified": "2015-07-30T23:29:08+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "7a390eac-db25-477b-80a9-7bbc051d87da",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/09011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09011.jpg"
+            "imagesrc": "/images/cards/en/09011.jpg"
         },
         {
             "last-modified": "2015-07-30T23:33:37+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "3c9f4821-0e6c-4e68-9666-d1784a0eca4e",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/09012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09012.jpg"
+            "imagesrc": "/images/cards/en/09012.jpg"
         },
         {
             "last-modified": "2015-10-02T20:38:45+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "f58ccb1d-d0f7-4339-abc7-6c017bac34c4",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/09013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09013.jpg"
+            "imagesrc": "/images/cards/en/09013.jpg"
         },
         {
             "last-modified": "2015-07-30T23:38:35+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "306a6cce-32c1-480f-b8a6-e239dad1379c",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/09014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09014.jpg"
+            "imagesrc": "/images/cards/en/09014.jpg"
         },
         {
             "last-modified": "2015-10-03T12:00:04+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "e5c43d70-6280-43e4-a0c6-8bc4239382e7",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/09015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09015.jpg"
+            "imagesrc": "/images/cards/en/09015.jpg"
         },
         {
             "last-modified": "2015-10-02T20:40:27+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "2256eecb-02d3-4d01-b407-3417a109691e",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/09016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09016.jpg"
+            "imagesrc": "/images/cards/en/09016.jpg"
         },
         {
             "last-modified": "2015-10-02T20:40:42+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "3b853568-7da7-40d2-952c-72b611330f11",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/09017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09017.jpg"
+            "imagesrc": "/images/cards/en/09017.jpg"
         },
         {
             "last-modified": "2015-10-02T20:40:59+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "381e141f-b745-4c05-b455-b4fe3c1fc73c",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/09018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09018.jpg"
+            "imagesrc": "/images/cards/en/09018.jpg"
         },
         {
             "last-modified": "2015-10-03T12:00:29+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "1456fe5c-9edb-4521-abd7-3a029851222d",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/09019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09019.jpg"
+            "imagesrc": "/images/cards/en/09019.jpg"
         },
         {
             "last-modified": "2015-10-02T20:41:18+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "ff016aea-9c16-44a6-bacf-4ee2ca9a913e",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/09020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09020.jpg"
+            "imagesrc": "/images/cards/en/09020.jpg"
         },
         {
             "last-modified": "2015-10-02T20:41:32+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "1086db48-f246-4e5f-a6d2-2bd6ebce9ba8",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/09021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09021.jpg"
+            "imagesrc": "/images/cards/en/09021.jpg"
         },
         {
             "last-modified": "2015-07-30T22:55:23+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "d9beac18-b2a7-451d-a17f-6b5202cd3b1a",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/09022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09022.jpg"
+            "imagesrc": "/images/cards/en/09022.jpg"
         },
         {
             "last-modified": "2015-07-30T23:00:25+02:00",
@@ -765,7 +765,7 @@
             "octgnid": "b49ca811-796c-4cb9-abd4-9657d88a9ceb",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/09023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09023.jpg"
+            "imagesrc": "/images/cards/en/09023.jpg"
         },
         {
             "last-modified": "2015-07-30T23:05:14+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "3b3815a8-ca49-48c0-96eb-d50d1d493d68",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/09024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09024.jpg"
+            "imagesrc": "/images/cards/en/09024.jpg"
         },
         {
             "last-modified": "2015-10-10T16:32:11+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "245f816f-f407-41e7-b8e6-9fb6cd638bf3",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/09025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09025.jpg"
+            "imagesrc": "/images/cards/en/09025.jpg"
         },
         {
             "last-modified": "2015-10-02T20:42:31+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "c665872f-61b0-4a23-b923-12ea6d5d8c95",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/09026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09026.jpg"
+            "imagesrc": "/images/cards/en/09026.jpg"
         },
         {
             "last-modified": "2015-10-02T20:42:44+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "7d921e83-5ac4-40c7-a756-4f596b1fe8ee",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/09027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09027.jpg"
+            "imagesrc": "/images/cards/en/09027.jpg"
         },
         {
             "last-modified": "2015-10-02T20:43:23+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "eed9713a-5a8b-4a10-91b1-4ecd27eee125",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/09028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09028.jpg"
+            "imagesrc": "/images/cards/en/09028.jpg"
         },
         {
             "last-modified": "2015-10-02T20:44:26+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "06c47afe-528b-416e-b068-5b609225afe0",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/09029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09029.jpg"
+            "imagesrc": "/images/cards/en/09029.jpg"
         },
         {
             "last-modified": "2015-10-02T20:44:45+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "f0e6f9a4-1a55-4cd6-9296-e06c823e22b2",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/09030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09030.jpg"
+            "imagesrc": "/images/cards/en/09030.jpg"
         },
         {
             "last-modified": "2015-10-02T20:45:04+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "d6931afe-58cd-430f-9fe2-178738614cf8",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/09031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09031.jpg"
+            "imagesrc": "/images/cards/en/09031.jpg"
         },
         {
             "last-modified": "2015-10-02T20:45:19+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "e4b062de-79ef-4005-a1e0-7ce0a4ed9d34",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/09032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09032.jpg"
+            "imagesrc": "/images/cards/en/09032.jpg"
         },
         {
             "last-modified": "2015-10-02T20:45:37+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "a655edaa-c2e8-41d3-9710-e96bf21fae1b",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/09033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09033.jpg"
+            "imagesrc": "/images/cards/en/09033.jpg"
         },
         {
             "last-modified": "2015-10-02T20:45:53+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "889fa2dd-dd3e-4830-8d59-7cb242e1c68e",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/09034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09034.jpg"
+            "imagesrc": "/images/cards/en/09034.jpg"
         },
         {
             "last-modified": "2015-10-02T20:46:22+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "79254945-f5f3-48ab-90d9-f1da1dd15d74",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/09035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09035.jpg"
+            "imagesrc": "/images/cards/en/09035.jpg"
         },
         {
             "last-modified": "2015-10-02T20:46:36+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "12fb4862-f1e1-4ad3-b28f-2206b1a194e9",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/09036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09036.jpg"
+            "imagesrc": "/images/cards/en/09036.jpg"
         },
         {
             "last-modified": "2015-10-10T16:37:07+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "c77c3030-224b-4cb2-bf27-7be6cf6d5fcc",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/09037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09037.jpg"
+            "imagesrc": "/images/cards/en/09037.jpg"
         },
         {
             "last-modified": "2015-10-10T16:37:13+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "c946d5d9-276e-4464-8958-c1bf3045a817",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/09038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09038.jpg"
+            "imagesrc": "/images/cards/en/09038.jpg"
         },
         {
             "last-modified": "2015-10-02T20:47:18+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "ceaefbb7-2540-44cf-abaf-755042f318ae",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/09039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09039.jpg"
+            "imagesrc": "/images/cards/en/09039.jpg"
         },
         {
             "last-modified": "2015-10-10T16:37:01+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "23a1a9a2-cfc2-478c-9d93-46c23cb6a567",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/09040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09040.jpg"
+            "imagesrc": "/images/cards/en/09040.jpg"
         },
         {
             "last-modified": "2015-07-30T23:51:56+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "53a212a6-34a6-47b0-bb24-45f1888bebf6",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/09041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09041.jpg"
+            "imagesrc": "/images/cards/en/09041.jpg"
         },
         {
             "last-modified": "2015-07-30T23:51:07+02:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "c4689399-c350-46b3-a79a-f8c62d926cd5",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/09042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/09042.jpg"
+            "imagesrc": "/images/cards/en/09042.jpg"
         }
     ]
 }

--- a/packs/NN.json
+++ b/packs/NN.json
@@ -39,7 +39,7 @@
             "octgnid": "85989968-0332-4dc2-a5eb-9921267453ff",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/08001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08001.jpg"
+            "imagesrc": "/images/cards/en/08001.jpg"
         },
         {
             "last-modified": "2015-10-02T20:28:03+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "4b50bf0d-29e3-4e93-8acc-f77c60b80e57",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/08002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08002.jpg"
+            "imagesrc": "/images/cards/en/08002.jpg"
         },
         {
             "last-modified": "2015-10-10T16:32:54+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "92d9bfc1-4be6-4973-b820-0ac65e5d7b01",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/08003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08003.jpg"
+            "imagesrc": "/images/cards/en/08003.jpg"
         },
         {
             "last-modified": "2017-03-25T11:42:36+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "65b724a9-49e4-4c1c-9db8-e3f3081fa3fe",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/08004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08004.jpg"
+            "imagesrc": "/images/cards/en/08004.jpg"
         },
         {
             "last-modified": "2015-10-02T20:28:46+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "e20afd82-c3d7-4152-aac9-4392a29733b8",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/08005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08005.jpg"
+            "imagesrc": "/images/cards/en/08005.jpg"
         },
         {
             "last-modified": "2015-07-30T22:33:51+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "c4b260a0-1861-4300-8c96-6064f7367cb5",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/08006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08006.jpg"
+            "imagesrc": "/images/cards/en/08006.jpg"
         },
         {
             "last-modified": "2015-10-02T20:29:18+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "686696a5-da6b-46d7-92b2-2ba051a3153e",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/08007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08007.jpg"
+            "imagesrc": "/images/cards/en/08007.jpg"
         },
         {
             "last-modified": "2015-10-02T20:29:33+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "ef19f3d5-a52f-403a-a342-ae32f3753120",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/08008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08008.jpg"
+            "imagesrc": "/images/cards/en/08008.jpg"
         },
         {
             "last-modified": "2015-10-02T20:29:58+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "8628bdf2-3900-4e36-941e-043560d81757",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/08009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08009.jpg"
+            "imagesrc": "/images/cards/en/08009.jpg"
         },
         {
             "last-modified": "2015-10-02T20:30:16+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "29add78a-5369-43d9-80d9-4006f6757a6e",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/08010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08010.jpg"
+            "imagesrc": "/images/cards/en/08010.jpg"
         },
         {
             "last-modified": "2015-07-22T20:56:09+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "5529098d-fd5f-41c1-9121-58a4c2b41c89",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/08011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08011.jpg"
+            "imagesrc": "/images/cards/en/08011.jpg"
         },
         {
             "last-modified": "2015-10-03T11:58:00+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "5448fd9b-6cce-4973-a40a-f4769b7f6f47",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/08012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08012.jpg"
+            "imagesrc": "/images/cards/en/08012.jpg"
         },
         {
             "last-modified": "2015-10-10T16:32:48+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "6da3418d-0c64-425c-8191-680e7f2480b3",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/08013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08013.jpg"
+            "imagesrc": "/images/cards/en/08013.jpg"
         },
         {
             "last-modified": "2015-10-02T20:31:44+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "0c37b916-b5e6-4e43-8640-8a970465b70e",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/08014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08014.jpg"
+            "imagesrc": "/images/cards/en/08014.jpg"
         },
         {
             "last-modified": "2019-06-17T00:32:41+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "80905177-39e7-49fd-a244-aa6c70baa9e8",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/08015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08015.jpg"
+            "imagesrc": "/images/cards/en/08015.jpg"
         },
         {
             "last-modified": "2015-10-02T20:32:19+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "59978194-81c0-482e-8748-1df5b3a6245f",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/08016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08016.jpg"
+            "imagesrc": "/images/cards/en/08016.jpg"
         },
         {
             "last-modified": "2015-10-02T20:32:46+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "abed8d3b-d73f-4426-bbeb-6e0124aae9fb",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/08017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08017.jpg"
+            "imagesrc": "/images/cards/en/08017.jpg"
         },
         {
             "last-modified": "2015-10-02T20:33:00+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "39e4ddd4-987b-450b-a3dd-260a20db35a0",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/08018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08018.jpg"
+            "imagesrc": "/images/cards/en/08018.jpg"
         },
         {
             "last-modified": "2015-10-02T20:33:16+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "3f0bc78c-6b5d-4951-bcd1-a3ab3b08481e",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/08019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08019.jpg"
+            "imagesrc": "/images/cards/en/08019.jpg"
         },
         {
             "last-modified": "2015-10-02T20:33:28+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "e5e6dd23-04d0-4614-a8da-a9a74785a7c2",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/08020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08020.jpg"
+            "imagesrc": "/images/cards/en/08020.jpg"
         },
         {
             "last-modified": "2015-10-02T20:33:42+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "590b905c-f114-48d2-930f-66e446458c84",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/08021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/08021.jpg"
+            "imagesrc": "/images/cards/en/08021.jpg"
         }
     ]
 }

--- a/packs/NTB.json
+++ b/packs/NTB.json
@@ -39,7 +39,7 @@
             "octgnid": "2cba8b31-062a-4701-a9a4-76a330681bb7",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/07001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07001.jpg"
+            "imagesrc": "/images/cards/en/07001.jpg"
         },
         {
             "last-modified": "2015-10-02T20:18:01+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "04e204a6-8879-477b-8153-adcda50b1f51",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/07002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07002.jpg"
+            "imagesrc": "/images/cards/en/07002.jpg"
         },
         {
             "last-modified": "2015-10-03T11:56:09+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "799ea10c-9dc3-414e-bd72-c1d9fa662926",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/07003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07003.jpg"
+            "imagesrc": "/images/cards/en/07003.jpg"
         },
         {
             "last-modified": "2015-10-02T20:18:40+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "294a7ce9-af00-46e1-b33c-aab21ebf3b09",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/07004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07004.jpg"
+            "imagesrc": "/images/cards/en/07004.jpg"
         },
         {
             "last-modified": "2015-06-30T07:06:54+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "56fd7d6b-d14a-4b9d-a29c-40102bf4377b",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/07005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07005.jpg"
+            "imagesrc": "/images/cards/en/07005.jpg"
         },
         {
             "last-modified": "2015-10-02T20:20:02+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "fffb2b62-4d83-4b3c-9696-2905477d892f",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/07006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07006.jpg"
+            "imagesrc": "/images/cards/en/07006.jpg"
         },
         {
             "last-modified": "2015-10-02T20:21:10+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "4d2ffa2b-f09d-47ef-845b-d227b060b603",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/07007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07007.jpg"
+            "imagesrc": "/images/cards/en/07007.jpg"
         },
         {
             "last-modified": "2015-10-02T20:21:30+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "9eada35c-a9a5-485f-9513-305661421944",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/07008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07008.jpg"
+            "imagesrc": "/images/cards/en/07008.jpg"
         },
         {
             "last-modified": "2015-10-03T11:56:24+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "c65152fd-434e-4729-ac44-cf61d1affbdc",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/07009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07009.jpg"
+            "imagesrc": "/images/cards/en/07009.jpg"
         },
         {
             "last-modified": "2015-06-12T12:08:28+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "0334ecdd-6da1-47bf-a3d0-b4988bdf8a07",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/07010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07010.jpg"
+            "imagesrc": "/images/cards/en/07010.jpg"
         },
         {
             "last-modified": "2015-10-02T20:22:20+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "5af04c4c-8282-4abf-9e55-a13ace8a998b",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/07011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07011.jpg"
+            "imagesrc": "/images/cards/en/07011.jpg"
         },
         {
             "last-modified": "2015-10-03T11:56:52+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "68bce669-132a-43ca-9727-8de86b3b039c",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/07012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07012.jpg"
+            "imagesrc": "/images/cards/en/07012.jpg"
         },
         {
             "last-modified": "2015-10-02T20:23:06+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "34970b97-c353-47a5-bf1c-4cdc0351eef5",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/07013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07013.jpg"
+            "imagesrc": "/images/cards/en/07013.jpg"
         },
         {
             "last-modified": "2015-10-02T20:23:26+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "b756df9e-6c24-4b33-a6f1-ff6b82dd51e5",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/07014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07014.jpg"
+            "imagesrc": "/images/cards/en/07014.jpg"
         },
         {
             "last-modified": "2015-06-10T14:36:30+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "2950ad4b-c835-415f-a24c-b61c9702c728",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/07015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07015.jpg"
+            "imagesrc": "/images/cards/en/07015.jpg"
         },
         {
             "last-modified": "2015-10-03T11:57:33+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "03dc1c9f-3b91-4bf6-af64-6bcbdca36839",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/07016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07016.jpg"
+            "imagesrc": "/images/cards/en/07016.jpg"
         },
         {
             "last-modified": "2015-10-02T20:24:41+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "00867833-050d-4214-bccb-d1e787f15baf",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/07017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07017.jpg"
+            "imagesrc": "/images/cards/en/07017.jpg"
         },
         {
             "last-modified": "2016-02-23T20:55:02+01:00",
@@ -600,7 +600,7 @@
             "octgnid": "12d7d9e6-cffa-46ef-8ae7-d8fbbeb88e4c",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/07018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07018.jpg"
+            "imagesrc": "/images/cards/en/07018.jpg"
         },
         {
             "last-modified": "2015-10-02T20:25:14+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "f7d5aaa2-b476-4156-bef1-697cd39d7dd7",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/07019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07019.jpg"
+            "imagesrc": "/images/cards/en/07019.jpg"
         },
         {
             "last-modified": "2015-10-02T20:25:31+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "0453a270-56fb-4714-b3d7-41129bf4ccd5",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/07020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07020.jpg"
+            "imagesrc": "/images/cards/en/07020.jpg"
         },
         {
             "last-modified": "2017-11-16T18:40:02+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "b308c49b-6871-4067-a269-9aa7f8917bdc",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/07021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/07021.jpg"
+            "imagesrc": "/images/cards/en/07021.jpg"
         }
     ]
 }

--- a/packs/NTNR.json
+++ b/packs/NTNR.json
@@ -39,7 +39,7 @@
             "octgnid": "77653869-e142-4428-8595-c74886e8c8c8",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/02001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02001.jpg"
+            "imagesrc": "/images/cards/en/02001.jpg"
         },
         {
             "last-modified": "2015-09-28T17:12:55+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "d9aefb8f-ea66-4782-8fee-1e5c88c257af",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/02002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02002.jpg"
+            "imagesrc": "/images/cards/en/02002.jpg"
         },
         {
             "last-modified": "2015-09-28T17:12:37+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "dec376dc-2dcd-4cb8-b1ae-9c4dc7c7dd7e",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/02003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02003.jpg"
+            "imagesrc": "/images/cards/en/02003.jpg"
         },
         {
             "last-modified": "2014-11-04T08:10:07+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "cbb6be72-e387-4742-99cb-b5681e88de82",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/02004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02004.jpg"
+            "imagesrc": "/images/cards/en/02004.jpg"
         },
         {
             "last-modified": "2015-09-28T17:12:20+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "826655e8-00b7-43ae-a3fb-4cea781176ad",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/02005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02005.jpg"
+            "imagesrc": "/images/cards/en/02005.jpg"
         },
         {
             "last-modified": "2015-09-28T17:12:03+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "32f4797f-7584-453c-b6a3-9cf3656dcc96",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/02006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02006.jpg"
+            "imagesrc": "/images/cards/en/02006.jpg"
         },
         {
             "last-modified": "2015-09-28T17:11:17+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "15fda041-c825-4278-a5de-15bc00cab80d",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/02007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02007.jpg"
+            "imagesrc": "/images/cards/en/02007.jpg"
         },
         {
             "last-modified": "2015-09-28T17:11:35+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "55257be5-9428-4699-8df6-9b397f9fe258",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/02008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02008.jpg"
+            "imagesrc": "/images/cards/en/02008.jpg"
         },
         {
             "last-modified": "2014-12-16T08:48:11+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "c765b5ba-c7b1-491c-b504-fcce730bb8a0",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/02009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02009.jpg"
+            "imagesrc": "/images/cards/en/02009.jpg"
         },
         {
             "last-modified": "2014-11-04T08:10:07+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "0203a928-b0b6-4a95-8e71-d82b02a48e9a",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/02010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02010.jpg"
+            "imagesrc": "/images/cards/en/02010.jpg"
         },
         {
             "last-modified": "2015-09-28T17:10:37+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "aa9e21f5-9a84-479b-90f8-497b6084467b",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/02011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02011.jpg"
+            "imagesrc": "/images/cards/en/02011.jpg"
         },
         {
             "last-modified": "2015-09-28T17:01:02+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "ce8a1161-2c83-4a6f-a0de-7a6c19b47a6e",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/02012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02012.jpg"
+            "imagesrc": "/images/cards/en/02012.jpg"
         },
         {
             "last-modified": "2015-09-28T17:01:55+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "b65c9b55-7a81-4052-87dd-70eb515b8b2f",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/02013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02013.jpg"
+            "imagesrc": "/images/cards/en/02013.jpg"
         },
         {
             "last-modified": "2015-09-28T17:02:38+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "bf48f3c1-bd08-4542-a8c6-6af0a8e7cfa4",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/02014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02014.jpg"
+            "imagesrc": "/images/cards/en/02014.jpg"
         },
         {
             "last-modified": "2015-09-28T17:03:45+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "d6c082a2-8e92-404b-b427-a1f7a7cab4aa",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/02015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02015.jpg"
+            "imagesrc": "/images/cards/en/02015.jpg"
         },
         {
             "last-modified": "2017-03-25T11:42:54+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "18e06cc3-eb57-451a-ba28-18665727999d",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/02016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02016.jpg"
+            "imagesrc": "/images/cards/en/02016.jpg"
         },
         {
             "last-modified": "2015-10-04T14:26:09+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "0857fa1d-c061-4606-bb55-4736edcfd2e9",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/02017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02017.jpg"
+            "imagesrc": "/images/cards/en/02017.jpg"
         },
         {
             "last-modified": "2015-09-28T20:17:59+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "7bb386d8-73a0-4d31-bbd1-5204fcde0302",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/02018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02018.jpg"
+            "imagesrc": "/images/cards/en/02018.jpg"
         },
         {
             "last-modified": "2015-09-28T20:29:22+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "ef91b1f5-46b8-4246-8e58-401a39ebbf6f",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/02019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02019.jpg"
+            "imagesrc": "/images/cards/en/02019.jpg"
         },
         {
             "last-modified": "2015-09-28T20:18:10+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "1b68d5c9-e336-4822-aeb9-5ca0cace82a8",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/02020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02020.jpg"
+            "imagesrc": "/images/cards/en/02020.jpg"
         },
         {
             "last-modified": "2015-09-28T20:17:39+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "519a9e2e-56e9-42a2-8cda-64d1a7cd934f",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/02021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/02021.jpg"
+            "imagesrc": "/images/cards/en/02021.jpg"
         }
     ]
 }

--- a/packs/O4B.json
+++ b/packs/O4B.json
@@ -39,7 +39,7 @@
             "octgnid": "f7c44d33-acb0-405b-b423-d7b9e6468b3a",
             "value": "",
             "url": "https://dtdb.co/en/card/21001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21001.jpg"
+            "imagesrc": "/images/cards/en/21001.jpg"
         },
         {
             "last-modified": "2019-06-14T17:58:35+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "409d1eba-9f66-9e24-9967-edc1a96ec4e2",
             "value": "",
             "url": "https://dtdb.co/en/card/21002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21002.jpg"
+            "imagesrc": "/images/cards/en/21002.jpg"
         },
         {
             "last-modified": "2019-02-04T00:09:50+01:00",
@@ -105,7 +105,7 @@
             "octgnid": "85600051-92b4-a1e0-2e4d-65044d210164",
             "value": "",
             "url": "https://dtdb.co/en/card/21003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21003.jpg"
+            "imagesrc": "/images/cards/en/21003.jpg"
         },
         {
             "last-modified": "2019-02-04T00:11:33+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "0e0bdb93-c1fa-db9b-0fac-a19e2b3d622c",
             "value": "",
             "url": "https://dtdb.co/en/card/21004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21004.jpg"
+            "imagesrc": "/images/cards/en/21004.jpg"
         },
         {
             "last-modified": "2019-05-30T17:23:15+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "afc89031-a660-00a4-8533-97d50ed8d4e2",
             "value": "",
             "url": "https://dtdb.co/en/card/21005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21005.jpg"
+            "imagesrc": "/images/cards/en/21005.jpg"
         },
         {
             "last-modified": "2019-02-04T00:10:42+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "91f9e67f-e18f-bb2d-05ae-a13f6ea11fb0",
             "value": "",
             "url": "https://dtdb.co/en/card/21006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21006.jpg"
+            "imagesrc": "/images/cards/en/21006.jpg"
         },
         {
             "last-modified": "2019-05-30T17:28:20+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "8ac81a66-9e71-7413-af60-40b007b31c0e",
             "value": "",
             "url": "https://dtdb.co/en/card/21007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21007.jpg"
+            "imagesrc": "/images/cards/en/21007.jpg"
         },
         {
             "last-modified": "2019-05-30T17:28:48+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "4ffa4a62-2427-270b-5e74-2eea7d929c58",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/21008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21008.jpg"
+            "imagesrc": "/images/cards/en/21008.jpg"
         },
         {
             "last-modified": "2019-06-14T18:02:22+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "d6dcaddd-7bfa-1653-31fc-321222181729",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/21009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21009.jpg"
+            "imagesrc": "/images/cards/en/21009.jpg"
         },
         {
             "last-modified": "2019-06-14T18:04:05+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "6080e7a5-917f-ae00-0c7d-cf8971489d29",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/21010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21010.jpg"
+            "imagesrc": "/images/cards/en/21010.jpg"
         },
         {
             "last-modified": "2019-06-14T18:05:11+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "9807eed4-2872-1ec7-5c15-d6bbc8b794d1",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/21011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21011.jpg"
+            "imagesrc": "/images/cards/en/21011.jpg"
         },
         {
             "last-modified": "2019-06-14T18:06:11+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "aaa35070-83aa-af52-b701-fcbba379c127",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/21012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21012.jpg"
+            "imagesrc": "/images/cards/en/21012.jpg"
         },
         {
             "last-modified": "2019-02-04T00:12:34+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "6872cce2-e0b1-96db-572e-d537d2f846a8",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/21013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21013.jpg"
+            "imagesrc": "/images/cards/en/21013.jpg"
         },
         {
             "last-modified": "2019-06-16T03:25:57+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "60b58038-1cbb-d970-c289-074b26700e76",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/21014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21014.jpg"
+            "imagesrc": "/images/cards/en/21014.jpg"
         },
         {
             "last-modified": "2019-02-05T18:07:15+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "b4fbeb36-b469-40a3-749b-0ce2b980a23f",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/21015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21015.jpg"
+            "imagesrc": "/images/cards/en/21015.jpg"
         },
         {
             "last-modified": "2019-06-16T03:29:43+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "41e73eee-c0fb-dcf1-0472-2109b298ed6c",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/21016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21016.jpg"
+            "imagesrc": "/images/cards/en/21016.jpg"
         },
         {
             "last-modified": "2019-06-14T18:11:22+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "de59a222-8544-de7c-f897-4af058263772",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/21017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21017.jpg"
+            "imagesrc": "/images/cards/en/21017.jpg"
         },
         {
             "last-modified": "2019-06-14T18:13:18+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "b515134b-65d1-3c3b-d2f5-dfc74b3e9da8",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/21018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21018.jpg"
+            "imagesrc": "/images/cards/en/21018.jpg"
         },
         {
             "last-modified": "2019-06-14T18:15:45+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "666dab03-ed30-d7ed-51f8-2793d4183f45",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/21019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21019.jpg"
+            "imagesrc": "/images/cards/en/21019.jpg"
         },
         {
             "last-modified": "2019-06-14T18:16:46+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "a900059b-bfb6-d6a2-e017-8d549774665a",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/21020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21020.jpg"
+            "imagesrc": "/images/cards/en/21020.jpg"
         },
         {
             "last-modified": "2019-06-14T18:18:18+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "91ad1f4b-d6f1-13d0-ef3b-1b04a3da3e0e",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/21021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21021.jpg"
+            "imagesrc": "/images/cards/en/21021.jpg"
         },
         {
             "last-modified": "2019-06-14T18:20:04+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "92762db4-a795-b339-750f-40d3825e1a39",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/21022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21022.jpg"
+            "imagesrc": "/images/cards/en/21022.jpg"
         },
         {
             "last-modified": "2019-06-14T18:23:21+02:00",
@@ -765,7 +765,7 @@
             "octgnid": "af6e568e-9008-0fa9-818c-ebc155a697e5",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/21023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21023.jpg"
+            "imagesrc": "/images/cards/en/21023.jpg"
         },
         {
             "last-modified": "2019-05-30T17:34:58+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "537bca8b-1a35-c942-fe78-d44ae3c27527",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/21024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21024.jpg"
+            "imagesrc": "/images/cards/en/21024.jpg"
         },
         {
             "last-modified": "2019-06-16T03:34:44+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "95288f06-e928-1467-80b5-3fba16475b57",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/21025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21025.jpg"
+            "imagesrc": "/images/cards/en/21025.jpg"
         },
         {
             "last-modified": "2019-06-16T03:44:54+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "1f793cbc-37f2-4185-65ee-c29746d44d5f",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/21026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21026.jpg"
+            "imagesrc": "/images/cards/en/21026.jpg"
         },
         {
             "last-modified": "2019-06-16T03:46:21+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "b53b350e-2933-5856-d09a-2f809d4aa786",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/21027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21027.jpg"
+            "imagesrc": "/images/cards/en/21027.jpg"
         },
         {
             "last-modified": "2019-06-16T03:47:33+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "9a364e65-b1f3-bc1b-f5ff-22af20d5f484",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/21028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21028.jpg"
+            "imagesrc": "/images/cards/en/21028.jpg"
         },
         {
             "last-modified": "2019-06-16T03:53:20+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "761e1121-6b53-6f8f-7ae7-a21957d97b76",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/21029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21029.jpg"
+            "imagesrc": "/images/cards/en/21029.jpg"
         },
         {
             "last-modified": "2019-06-16T23:28:18+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "8788feb4-409c-1048-afb6-f4d11453255c",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/21030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21030.jpg"
+            "imagesrc": "/images/cards/en/21030.jpg"
         },
         {
             "last-modified": "2019-06-16T23:29:13+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "b29a0155-5019-a272-bb47-fd45b485b135",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/21031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21031.jpg"
+            "imagesrc": "/images/cards/en/21031.jpg"
         },
         {
             "last-modified": "2019-06-16T23:30:35+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "b558faf1-8ed8-f8f5-c661-90019f0d6d61",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/21032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21032.jpg"
+            "imagesrc": "/images/cards/en/21032.jpg"
         },
         {
             "last-modified": "2019-06-16T23:32:19+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "eabe0b00-67ec-7be0-a030-d6c35eb92a0d",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/21033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21033.jpg"
+            "imagesrc": "/images/cards/en/21033.jpg"
         },
         {
             "last-modified": "2019-05-30T17:38:49+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "a582d4cc-805f-c49d-8115-f6a066e459d5",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/21034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21034.jpg"
+            "imagesrc": "/images/cards/en/21034.jpg"
         },
         {
             "last-modified": "2019-06-16T23:35:24+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "8abb6faf-b1a3-df04-022f-b8532581ddd3",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/21035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21035.jpg"
+            "imagesrc": "/images/cards/en/21035.jpg"
         },
         {
             "last-modified": "2019-05-24T22:03:51+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "d84b903d-dd0f-8e80-c7fa-54e9f2fe2770",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/21036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21036.jpg"
+            "imagesrc": "/images/cards/en/21036.jpg"
         },
         {
             "last-modified": "2019-06-16T23:37:39+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "3d5ee39c-5d5b-89b1-ed3e-9fe7d23c29f1",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/21037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21037.jpg"
+            "imagesrc": "/images/cards/en/21037.jpg"
         },
         {
             "last-modified": "2019-06-16T23:40:59+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "91a9982c-ca3a-1efd-1981-ba40a1f88a00",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/21038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21038.jpg"
+            "imagesrc": "/images/cards/en/21038.jpg"
         },
         {
             "last-modified": "2019-05-30T17:40:26+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "db7edcd0-004b-d152-f3aa-3a983594db41",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/21039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21039.jpg"
+            "imagesrc": "/images/cards/en/21039.jpg"
         },
         {
             "last-modified": "2019-02-04T00:13:17+01:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "7a660d76-48cb-3dc3-9325-54401b770469",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/21040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21040.jpg"
+            "imagesrc": "/images/cards/en/21040.jpg"
         },
         {
             "last-modified": "2019-05-30T17:41:12+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "b7b19a08-2bd0-cc0d-2262-e2cc0005a742",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/21041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21041.jpg"
+            "imagesrc": "/images/cards/en/21041.jpg"
         },
         {
             "last-modified": "2019-06-16T23:47:21+02:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "3b0be104-7fc9-8db4-a5c3-7d189a73c6af",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/21042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21042.jpg"
+            "imagesrc": "/images/cards/en/21042.jpg"
         },
         {
             "last-modified": "2019-06-17T00:25:44+02:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "e11656c2-ea70-799e-766a-b58a104585e7",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/21043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21043.jpg"
+            "imagesrc": "/images/cards/en/21043.jpg"
         },
         {
             "last-modified": "2019-06-17T00:30:57+02:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "87ae9741-b861-72ae-523a-072b57085e39",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/21044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21044.jpg"
+            "imagesrc": "/images/cards/en/21044.jpg"
         },
         {
             "last-modified": "2019-06-17T00:34:50+02:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "8c115b49-44f4-0ec9-f08e-1e4ff6d3b30b",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/21045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21045.jpg"
+            "imagesrc": "/images/cards/en/21045.jpg"
         },
         {
             "last-modified": "2019-05-30T17:43:00+02:00",
@@ -1524,7 +1524,7 @@
             "octgnid": "0c2524c4-0861-ecf7-6177-210a8321947c",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/21046",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21046.jpg"
+            "imagesrc": "/images/cards/en/21046.jpg"
         },
         {
             "last-modified": "2019-05-30T17:43:23+02:00",
@@ -1557,7 +1557,7 @@
             "octgnid": "cda89314-ec5e-401d-3f5a-7e57e55aa80d",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/21047",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21047.jpg"
+            "imagesrc": "/images/cards/en/21047.jpg"
         },
         {
             "last-modified": "2019-05-30T17:43:43+02:00",
@@ -1590,7 +1590,7 @@
             "octgnid": "e881abd7-b68d-bf1b-c811-ece3574735ad",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/21048",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21048.jpg"
+            "imagesrc": "/images/cards/en/21048.jpg"
         },
         {
             "last-modified": "2019-06-17T00:38:49+02:00",
@@ -1623,7 +1623,7 @@
             "octgnid": "13d69444-ddd2-c272-fd46-f4f4c0514ca4",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/21049",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21049.jpg"
+            "imagesrc": "/images/cards/en/21049.jpg"
         },
         {
             "last-modified": "2019-06-17T00:39:44+02:00",
@@ -1656,7 +1656,7 @@
             "octgnid": "75c8ef97-b3fd-c1b9-01fc-28602b53d51d",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/21050",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21050.jpg"
+            "imagesrc": "/images/cards/en/21050.jpg"
         },
         {
             "last-modified": "2019-05-10T03:06:14+02:00",
@@ -1689,7 +1689,7 @@
             "octgnid": "cc092027-6877-a850-8f93-be35911d2909",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/21051",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21051.jpg"
+            "imagesrc": "/images/cards/en/21051.jpg"
         },
         {
             "last-modified": "2019-02-04T00:13:47+01:00",
@@ -1722,7 +1722,7 @@
             "octgnid": "1bb65618-90d9-0766-f606-3aede09da2b1",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/21052",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21052.jpg"
+            "imagesrc": "/images/cards/en/21052.jpg"
         },
         {
             "last-modified": "2019-06-17T00:41:30+02:00",
@@ -1755,7 +1755,7 @@
             "octgnid": "702d4343-ba33-adca-78c5-01f532350721",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/21053",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21053.jpg"
+            "imagesrc": "/images/cards/en/21053.jpg"
         },
         {
             "last-modified": "2019-05-30T17:45:18+02:00",
@@ -1788,7 +1788,7 @@
             "octgnid": "2d8b5584-d18d-f87b-b766-304b552eb130",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/21054",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21054.jpg"
+            "imagesrc": "/images/cards/en/21054.jpg"
         },
         {
             "last-modified": "2019-05-15T02:41:14+02:00",
@@ -1821,7 +1821,7 @@
             "octgnid": "be288ae2-728a-224d-c8dd-c24d9c795fb4",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/21055",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21055.jpg"
+            "imagesrc": "/images/cards/en/21055.jpg"
         },
         {
             "last-modified": "2019-05-30T17:45:39+02:00",
@@ -1854,7 +1854,7 @@
             "octgnid": "6aca9b4b-439e-1aeb-ae2c-bc1fb9503605",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/21056",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/21056.jpg"
+            "imagesrc": "/images/cards/en/21056.jpg"
         }
     ]
 }

--- a/packs/TCR.json
+++ b/packs/TCR.json
@@ -39,7 +39,7 @@
             "octgnid": "fe0b667f-b384-465c-8e3e-97b9f122031c",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/15001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15001.jpg"
+            "imagesrc": "/images/cards/en/15001.jpg"
         },
         {
             "last-modified": "2016-05-12T19:40:22+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "55f3b556-f7c1-4a0a-9f88-6f2a89635118",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/15002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15002.jpg"
+            "imagesrc": "/images/cards/en/15002.jpg"
         },
         {
             "last-modified": "2016-05-12T19:42:53+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "0e414687-3d4e-413a-93d1-eb7ccaf7364e",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/15003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15003.jpg"
+            "imagesrc": "/images/cards/en/15003.jpg"
         },
         {
             "last-modified": "2016-05-12T19:45:02+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "1f895c03-29d3-4c09-a884-2d24aea2c84e",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/15004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15004.jpg"
+            "imagesrc": "/images/cards/en/15004.jpg"
         },
         {
             "last-modified": "2018-01-05T18:06:22+01:00",
@@ -171,7 +171,7 @@
             "octgnid": "7e03d2ef-dde6-4219-afd4-608280aee7bb",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/15005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15005.jpg"
+            "imagesrc": "/images/cards/en/15005.jpg"
         },
         {
             "last-modified": "2016-05-12T19:48:50+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "22e58549-c649-457b-a3da-4507ecfc30ec",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/15006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15006.jpg"
+            "imagesrc": "/images/cards/en/15006.jpg"
         },
         {
             "last-modified": "2016-05-12T19:50:27+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "14d66d53-e32a-4077-a843-ec3b02e4b628",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/15007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15007.jpg"
+            "imagesrc": "/images/cards/en/15007.jpg"
         },
         {
             "last-modified": "2016-05-12T19:52:25+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "2dd93d6f-a777-4592-a4b2-224bd81bc08a",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/15008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15008.jpg"
+            "imagesrc": "/images/cards/en/15008.jpg"
         },
         {
             "last-modified": "2016-05-12T19:54:07+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "1db846be-917b-46a0-980d-4f43d2b83d2a",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/15009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15009.jpg"
+            "imagesrc": "/images/cards/en/15009.jpg"
         },
         {
             "last-modified": "2016-05-12T19:55:11+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "47391e41-4a0f-443b-91dc-e3b0e298fbf4",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/15010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15010.jpg"
+            "imagesrc": "/images/cards/en/15010.jpg"
         },
         {
             "last-modified": "2016-05-12T19:56:25+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "e116ab3d-a5d5-46a3-860a-bc629bd0c63b",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/15011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15011.jpg"
+            "imagesrc": "/images/cards/en/15011.jpg"
         },
         {
             "last-modified": "2016-05-12T19:57:27+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "05fc82d0-06e4-422e-9cd7-18110a50a244",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/15012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15012.jpg"
+            "imagesrc": "/images/cards/en/15012.jpg"
         },
         {
             "last-modified": "2016-05-12T19:59:12+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "aa2d0ea9-5ede-4074-b0f7-2e78656f0e15",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/15013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15013.jpg"
+            "imagesrc": "/images/cards/en/15013.jpg"
         },
         {
             "last-modified": "2016-05-12T20:01:09+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "fc2842bf-c9b0-4b79-875b-3e35d91a5af2",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/15014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15014.jpg"
+            "imagesrc": "/images/cards/en/15014.jpg"
         },
         {
             "last-modified": "2016-05-12T20:02:17+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "64605ce4-35a8-4167-8650-e9b99b0e0dd3",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/15015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15015.jpg"
+            "imagesrc": "/images/cards/en/15015.jpg"
         },
         {
             "last-modified": "2016-05-12T20:03:59+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "560d147e-37d3-4f17-91a5-33fcbd23deef",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/15016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15016.jpg"
+            "imagesrc": "/images/cards/en/15016.jpg"
         },
         {
             "last-modified": "2018-01-05T18:07:03+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "2d97b6cb-9387-4081-8be5-85bb0bba0039",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/15017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15017.jpg"
+            "imagesrc": "/images/cards/en/15017.jpg"
         },
         {
             "last-modified": "2016-05-12T20:07:10+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "53df6af3-7b21-4594-926d-9e3ec7e30274",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/15018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15018.jpg"
+            "imagesrc": "/images/cards/en/15018.jpg"
         },
         {
             "last-modified": "2018-01-05T18:07:32+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "e42451a8-c431-4b2b-a454-9b94c187dca6",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/15019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15019.jpg"
+            "imagesrc": "/images/cards/en/15019.jpg"
         },
         {
             "last-modified": "2018-01-05T18:07:56+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "8ac302b6-711f-41dc-9f0d-4ec19f16f813",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/15020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15020.jpg"
+            "imagesrc": "/images/cards/en/15020.jpg"
         },
         {
             "last-modified": "2016-05-12T20:11:40+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "c22ec64d-d7d6-4c06-b09d-4a827c0dbad3",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/15021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/15021.jpg"
+            "imagesrc": "/images/cards/en/15021.jpg"
         }
     ]
 }

--- a/packs/TCaR.json
+++ b/packs/TCaR.json
@@ -39,7 +39,7 @@
             "octgnid": "ae22bba2-cf1e-4038-b7bb-1d3429ca2daf",
             "value": "",
             "url": "https://dtdb.co/en/card/19001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19001.jpg"
+            "imagesrc": "/images/cards/en/19001.jpg"
         },
         {
             "last-modified": "2017-07-26T20:34:07+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "2733deda-5584-42e1-9dfd-d283ad68cf1f",
             "value": "",
             "url": "https://dtdb.co/en/card/19002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19002.jpg"
+            "imagesrc": "/images/cards/en/19002.jpg"
         },
         {
             "last-modified": "2017-07-26T20:36:10+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "6bcacb58-f902-483e-8f25-6eef33e9dd18",
             "value": "",
             "url": "https://dtdb.co/en/card/19003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19003.jpg"
+            "imagesrc": "/images/cards/en/19003.jpg"
         },
         {
             "last-modified": "2017-07-26T20:45:25+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "1d0ac7a8-da18-4a99-9467-02edf80e6258",
             "value": "",
             "url": "https://dtdb.co/en/card/19004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19004.jpg"
+            "imagesrc": "/images/cards/en/19004.jpg"
         },
         {
             "last-modified": "2017-07-26T01:36:36+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "b1d048cf-7e94-4129-b817-5e0980038796",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/19005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19005.jpg"
+            "imagesrc": "/images/cards/en/19005.jpg"
         },
         {
             "last-modified": "2017-10-10T22:55:44+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "0dff63ec-8e97-488d-87c1-d2505b44acc0",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/19006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19006.jpg"
+            "imagesrc": "/images/cards/en/19006.jpg"
         },
         {
             "last-modified": "2017-09-06T17:38:56+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "51fa6f06-ba8e-432d-aca5-639123f2b9b9",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/19007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19007.jpg"
+            "imagesrc": "/images/cards/en/19007.jpg"
         },
         {
             "last-modified": "2017-10-10T22:57:34+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "08137945-5919-4b1d-be80-6aff3f89118b",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/19008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19008.jpg"
+            "imagesrc": "/images/cards/en/19008.jpg"
         },
         {
             "last-modified": "2017-09-06T17:38:32+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "f8adf6a9-c944-4b37-98eb-c167c5bce2e7",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/19009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19009.jpg"
+            "imagesrc": "/images/cards/en/19009.jpg"
         },
         {
             "last-modified": "2017-10-10T22:56:58+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "dafad1b5-7067-4efa-b063-67a4c5c2b42a",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/19010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19010.jpg"
+            "imagesrc": "/images/cards/en/19010.jpg"
         },
         {
             "last-modified": "2017-09-06T17:38:04+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "720083f1-9fd9-4608-a112-9e0a28de43d2",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/19011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19011.jpg"
+            "imagesrc": "/images/cards/en/19011.jpg"
         },
         {
             "last-modified": "2017-10-10T23:00:32+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "fb433634-025d-4333-aa2b-e8c9d230d020",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/19012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19012.jpg"
+            "imagesrc": "/images/cards/en/19012.jpg"
         },
         {
             "last-modified": "2017-12-13T13:43:43+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "3d38ea0c-31d3-456e-a7cd-f7a66476395d",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/19013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19013.jpg"
+            "imagesrc": "/images/cards/en/19013.jpg"
         },
         {
             "last-modified": "2017-09-06T17:37:24+02:00",
@@ -468,7 +468,7 @@
             "octgnid": "ad68435b-5503-4af0-bd4e-7e5b15c04866",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/19014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19014.jpg"
+            "imagesrc": "/images/cards/en/19014.jpg"
         },
         {
             "last-modified": "2017-10-10T22:57:18+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "9f3d837e-e317-403c-a72d-c9b8a48f5bcf",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/19015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19015.jpg"
+            "imagesrc": "/images/cards/en/19015.jpg"
         },
         {
             "last-modified": "2017-09-06T17:36:49+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "711deb54-4548-4206-81af-77d5dcc8793a",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/19016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19016.jpg"
+            "imagesrc": "/images/cards/en/19016.jpg"
         },
         {
             "last-modified": "2017-11-16T02:50:37+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "5c6b6541-1253-4da2-a454-ce912ffcf474",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/19017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19017.jpg"
+            "imagesrc": "/images/cards/en/19017.jpg"
         },
         {
             "last-modified": "2017-09-06T17:36:10+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "06d454b8-8713-4bba-b0d6-d9152d52423a",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/19018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19018.jpg"
+            "imagesrc": "/images/cards/en/19018.jpg"
         },
         {
             "last-modified": "2017-10-12T17:33:53+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "b7eae322-2208-4ef6-8ff2-d7af7ef5d2a1",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/19019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19019.jpg"
+            "imagesrc": "/images/cards/en/19019.jpg"
         },
         {
             "last-modified": "2017-10-10T22:59:58+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "0d2710a6-4ed9-447c-9cfb-2536d2def29c",
             "value": "Diams2",
             "url": "https://dtdb.co/en/card/19020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19020.jpg"
+            "imagesrc": "/images/cards/en/19020.jpg"
         },
         {
             "last-modified": "2017-10-10T23:01:21+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "e8906b23-85f3-44f0-89bb-d1cff708e8b3",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/19021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19021.jpg"
+            "imagesrc": "/images/cards/en/19021.jpg"
         },
         {
             "last-modified": "2017-09-06T17:35:50+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "d95fe205-8bcb-4bc5-a895-501fe91a52f3",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/19022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19022.jpg"
+            "imagesrc": "/images/cards/en/19022.jpg"
         },
         {
             "last-modified": "2017-09-06T17:35:10+02:00",
@@ -765,7 +765,7 @@
             "octgnid": "2ee14351-c57d-4944-850c-d58cb5c8c304",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/19023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19023.jpg"
+            "imagesrc": "/images/cards/en/19023.jpg"
         },
         {
             "last-modified": "2017-10-10T22:58:04+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "67c733e3-1842-44fe-9c40-33d1aad47b4a",
             "value": "Diams9",
             "url": "https://dtdb.co/en/card/19024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19024.jpg"
+            "imagesrc": "/images/cards/en/19024.jpg"
         },
         {
             "last-modified": "2017-11-16T02:57:50+01:00",
@@ -831,7 +831,7 @@
             "octgnid": "162aaf13-fe99-4bb6-8fbe-9587d71bd666",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/19025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19025.jpg"
+            "imagesrc": "/images/cards/en/19025.jpg"
         },
         {
             "last-modified": "2017-11-05T04:02:33+01:00",
@@ -864,7 +864,7 @@
             "octgnid": "ed34d5f8-3376-4be1-9db7-64c50cdebab9",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/19026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19026.jpg"
+            "imagesrc": "/images/cards/en/19026.jpg"
         },
         {
             "last-modified": "2017-09-06T17:34:34+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "381ea2d4-eb1c-46e0-8aad-a500c406709a",
             "value": "Diams13",
             "url": "https://dtdb.co/en/card/19027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19027.jpg"
+            "imagesrc": "/images/cards/en/19027.jpg"
         },
         {
             "last-modified": "2017-10-10T22:59:22+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "e2fed23a-b50b-4632-858d-ffd622184e5c",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/19028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19028.jpg"
+            "imagesrc": "/images/cards/en/19028.jpg"
         },
         {
             "last-modified": "2017-09-06T17:34:01+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "14eb0493-5ea9-4b44-b955-303fcea47e64",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/19029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19029.jpg"
+            "imagesrc": "/images/cards/en/19029.jpg"
         },
         {
             "last-modified": "2017-11-05T03:50:03+01:00",
@@ -996,7 +996,7 @@
             "octgnid": "3572042d-4197-4753-830f-d138500aff64",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/19030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19030.jpg"
+            "imagesrc": "/images/cards/en/19030.jpg"
         },
         {
             "last-modified": "2017-11-16T02:51:24+01:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "1ae574d7-9dd2-4999-a73f-90008198c1b9",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/19031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19031.jpg"
+            "imagesrc": "/images/cards/en/19031.jpg"
         },
         {
             "last-modified": "2017-12-13T13:54:48+01:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "e527c15a-fce5-451a-b34d-51c9050d9cac",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/19032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19032.jpg"
+            "imagesrc": "/images/cards/en/19032.jpg"
         },
         {
             "last-modified": "2017-09-06T17:32:49+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "e3c6f0bb-a585-46b4-b530-bbe6f3347ae8",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/19033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19033.jpg"
+            "imagesrc": "/images/cards/en/19033.jpg"
         },
         {
             "last-modified": "2017-12-13T13:53:19+01:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "be8dd9d7-31f8-4cf6-aa37-5a18067bb067",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/19034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19034.jpg"
+            "imagesrc": "/images/cards/en/19034.jpg"
         },
         {
             "last-modified": "2017-10-10T22:59:42+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "c13ad872-7c89-44fc-8572-2da526866207",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/19035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19035.jpg"
+            "imagesrc": "/images/cards/en/19035.jpg"
         },
         {
             "last-modified": "2017-12-13T13:50:29+01:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "2e57f90e-6852-49a8-abdc-9d24be7018fe",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/19036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19036.jpg"
+            "imagesrc": "/images/cards/en/19036.jpg"
         },
         {
             "last-modified": "2017-09-06T17:31:54+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "d9433ac9-20fb-4f2f-adb5-8b11ee9045ff",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/19037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19037.jpg"
+            "imagesrc": "/images/cards/en/19037.jpg"
         },
         {
             "last-modified": "2017-09-06T18:24:21+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "f638e171-5064-4c25-b1b7-7e5d762025b1",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/19038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19038.jpg"
+            "imagesrc": "/images/cards/en/19038.jpg"
         },
         {
             "last-modified": "2017-12-13T13:49:41+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "6afef9d1-9502-437b-915f-6450a35b3f30",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/19039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19039.jpg"
+            "imagesrc": "/images/cards/en/19039.jpg"
         },
         {
             "last-modified": "2017-12-13T13:46:47+01:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "71e424b2-d62f-43a4-95c8-4b6b77e0b83d",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/19040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19040.jpg"
+            "imagesrc": "/images/cards/en/19040.jpg"
         },
         {
             "last-modified": "2017-12-13T13:45:07+01:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "d759b266-2dbb-4ee8-8a8f-40e456cbd5ae",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/19041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19041.jpg"
+            "imagesrc": "/images/cards/en/19041.jpg"
         },
         {
             "last-modified": "2017-12-13T13:44:20+01:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "3560016d-7c5f-4ac3-beb8-c3360539bb11",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/19042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19042.jpg"
+            "imagesrc": "/images/cards/en/19042.jpg"
         },
         {
             "last-modified": "2017-09-06T16:52:47+02:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "2d759fe3-f3e0-46c2-82f1-1df7c5b32aac",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/19043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19043.jpg"
+            "imagesrc": "/images/cards/en/19043.jpg"
         },
         {
             "last-modified": "2017-09-06T16:55:36+02:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "e94de78b-0021-4167-9681-81b7cc5a9544",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/19044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19044.jpg"
+            "imagesrc": "/images/cards/en/19044.jpg"
         },
         {
             "last-modified": "2017-09-06T16:54:56+02:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "4c658294-3640-4362-9dde-719b4e348e21",
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/19045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/19045.jpg"
+            "imagesrc": "/images/cards/en/19045.jpg"
         }
     ]
 }

--- a/packs/TLS.json
+++ b/packs/TLS.json
@@ -39,7 +39,7 @@
             "octgnid": "6f9a4a04-411a-4c2b-b4c2-4db8d6c18157",
             "value": "",
             "url": "https://dtdb.co/en/card/10001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10001.jpg"
+            "imagesrc": "/images/cards/en/10001.jpg"
         },
         {
             "last-modified": "2015-10-06T19:16:59+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "24d74ad6-5532-4a11-ac66-a8b9f258cbf9",
             "value": "",
             "url": "https://dtdb.co/en/card/10002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10002.jpg"
+            "imagesrc": "/images/cards/en/10002.jpg"
         },
         {
             "last-modified": "2015-10-11T08:46:30+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "922a0a4b-c9b6-404a-b26b-87f079fc7a6c",
             "value": "",
             "url": "https://dtdb.co/en/card/10003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10003.jpg"
+            "imagesrc": "/images/cards/en/10003.jpg"
         },
         {
             "last-modified": "2015-10-02T18:09:14+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "ad7f9fb2-c845-49bd-82e2-0a94037e1d77",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/10004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10004.jpg"
+            "imagesrc": "/images/cards/en/10004.jpg"
         },
         {
             "last-modified": "2015-10-06T19:18:27+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "45a5acd3-3659-4654-8033-44ef084e1dba",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/10005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10005.jpg"
+            "imagesrc": "/images/cards/en/10005.jpg"
         },
         {
             "last-modified": "2015-10-04T14:26:56+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "a0a7fb60-18a3-4a8e-8dd1-a92931e724b1",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/10006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10006.jpg"
+            "imagesrc": "/images/cards/en/10006.jpg"
         },
         {
             "last-modified": "2015-10-06T19:22:17+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "ca460412-7ba2-4b04-8ec2-44c86460ce1a",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/10007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10007.jpg"
+            "imagesrc": "/images/cards/en/10007.jpg"
         },
         {
             "last-modified": "2015-10-06T19:23:42+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "ea2ecabb-966e-466f-a285-29028dba628b",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/10008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10008.jpg"
+            "imagesrc": "/images/cards/en/10008.jpg"
         },
         {
             "last-modified": "2015-10-06T19:25:39+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "aae392c5-3374-42af-827d-653a9ced3e9b",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/10009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10009.jpg"
+            "imagesrc": "/images/cards/en/10009.jpg"
         },
         {
             "last-modified": "2015-09-26T10:16:52+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "ad157676-5166-40b3-99a4-9cbe1300366d",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/10010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10010.jpg"
+            "imagesrc": "/images/cards/en/10010.jpg"
         },
         {
             "last-modified": "2017-03-25T11:41:21+01:00",
@@ -369,7 +369,7 @@
             "octgnid": "e1d93d5b-222d-4a82-b18f-62728f7791c0",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/10011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10011.jpg"
+            "imagesrc": "/images/cards/en/10011.jpg"
         },
         {
             "last-modified": "2015-10-06T19:30:33+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "d775dd42-183d-4165-83ed-3d825ea051a2",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/10012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10012.jpg"
+            "imagesrc": "/images/cards/en/10012.jpg"
         },
         {
             "last-modified": "2015-10-06T19:33:16+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "11c7f4dc-334e-466f-868a-d5df9157322e",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/10013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10013.jpg"
+            "imagesrc": "/images/cards/en/10013.jpg"
         },
         {
             "last-modified": "2018-01-05T18:04:49+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "5005c7d4-a6f3-440d-ae61-dc75412266fb",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/10014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10014.jpg"
+            "imagesrc": "/images/cards/en/10014.jpg"
         },
         {
             "last-modified": "2019-04-18T20:38:13+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "a17a638e-7ad1-4216-8748-f9526be7107a",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/10015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10015.jpg"
+            "imagesrc": "/images/cards/en/10015.jpg"
         },
         {
             "last-modified": "2015-10-06T19:39:30+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "8aa596d9-7b03-4939-9217-3b150fbe77d1",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/10016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10016.jpg"
+            "imagesrc": "/images/cards/en/10016.jpg"
         },
         {
             "last-modified": "2018-06-03T02:20:22+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "6a8c7f99-7f5c-4824-99b7-a9c5f9d9d715",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/10017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10017.jpg"
+            "imagesrc": "/images/cards/en/10017.jpg"
         },
         {
             "last-modified": "2015-10-02T18:03:52+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "89b1a934-a4a5-4900-a3b7-f2c5c98f1d1d",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/10018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10018.jpg"
+            "imagesrc": "/images/cards/en/10018.jpg"
         },
         {
             "last-modified": "2015-10-04T14:27:34+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "2c14e947-f0de-4049-8016-9d4679f9b2a5",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/10019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10019.jpg"
+            "imagesrc": "/images/cards/en/10019.jpg"
         },
         {
             "last-modified": "2015-09-26T10:12:55+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "ff370ba2-fd39-4996-ae02-abd3f46c9af7",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/10020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10020.jpg"
+            "imagesrc": "/images/cards/en/10020.jpg"
         },
         {
             "last-modified": "2015-10-02T18:00:08+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "b5ef38d4-d929-4a54-8ac8-36871ba2d66a",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/10021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10021.jpg"
+            "imagesrc": "/images/cards/en/10021.jpg"
         },
         {
             "last-modified": "2015-10-06T19:41:01+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "9312b25c-db3d-4889-9c6e-8b4ec495f3a8",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/10022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10022.jpg"
+            "imagesrc": "/images/cards/en/10022.jpg"
         },
         {
             "last-modified": "2017-11-22T18:06:40+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "a2cae75c-ac0b-437b-a951-a9e891ce4034",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/10023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10023.jpg"
+            "imagesrc": "/images/cards/en/10023.jpg"
         },
         {
             "last-modified": "2015-10-10T16:29:12+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "88967399-9c8c-4502-bf63-5f442aff836b",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/10024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10024.jpg"
+            "imagesrc": "/images/cards/en/10024.jpg"
         },
         {
             "last-modified": "2015-10-10T16:34:51+02:00",
@@ -831,7 +831,7 @@
             "octgnid": "95d23e7f-daa9-44ef-bcd3-50683340db62",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/10025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10025.jpg"
+            "imagesrc": "/images/cards/en/10025.jpg"
         },
         {
             "last-modified": "2015-10-06T19:49:02+02:00",
@@ -864,7 +864,7 @@
             "octgnid": "31a6a524-0191-4034-a20c-ec3008d28a6e",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/10026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10026.jpg"
+            "imagesrc": "/images/cards/en/10026.jpg"
         },
         {
             "last-modified": "2015-10-06T19:50:32+02:00",
@@ -897,7 +897,7 @@
             "octgnid": "2a59bc29-adca-4b5c-94f3-e9c94353d4b5",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/10027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10027.jpg"
+            "imagesrc": "/images/cards/en/10027.jpg"
         },
         {
             "last-modified": "2015-10-06T19:51:37+02:00",
@@ -930,7 +930,7 @@
             "octgnid": "507348af-e310-42c1-9878-c8c605882128",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/10028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10028.jpg"
+            "imagesrc": "/images/cards/en/10028.jpg"
         },
         {
             "last-modified": "2015-10-06T19:53:21+02:00",
@@ -963,7 +963,7 @@
             "octgnid": "98b3a9a9-3ab6-4413-b6c0-cc113ed26731",
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/10029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10029.jpg"
+            "imagesrc": "/images/cards/en/10029.jpg"
         },
         {
             "last-modified": "2015-10-10T16:29:27+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "899f3c84-3f9f-4589-83d9-2c2fe663d6a2",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/10030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10030.jpg"
+            "imagesrc": "/images/cards/en/10030.jpg"
         },
         {
             "last-modified": "2015-10-06T19:56:30+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "c5f02d5f-ad42-452f-8a7d-b48f58c6e76b",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/10031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10031.jpg"
+            "imagesrc": "/images/cards/en/10031.jpg"
         },
         {
             "last-modified": "2015-10-06T19:57:42+02:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "aea19556-2c30-4e03-a677-d0e6f6fa6c66",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/10032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10032.jpg"
+            "imagesrc": "/images/cards/en/10032.jpg"
         },
         {
             "last-modified": "2015-10-06T19:58:43+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "03da32d4-2e32-43d3-94c7-f3457414d298",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/10033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10033.jpg"
+            "imagesrc": "/images/cards/en/10033.jpg"
         },
         {
             "last-modified": "2015-10-06T20:01:02+02:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "b4a04153-f279-4feb-aa29-a9e86607dd3b",
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/10034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10034.jpg"
+            "imagesrc": "/images/cards/en/10034.jpg"
         },
         {
             "last-modified": "2015-10-06T20:02:22+02:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "ba290d31-e66f-427d-bc33-65200b20ad52",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/10035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10035.jpg"
+            "imagesrc": "/images/cards/en/10035.jpg"
         },
         {
             "last-modified": "2015-10-06T20:03:36+02:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "d332f810-af0a-42ee-9649-a4b34809a6e1",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/10036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10036.jpg"
+            "imagesrc": "/images/cards/en/10036.jpg"
         },
         {
             "last-modified": "2015-10-06T20:05:22+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "82cd476b-6ff5-4f49-adad-a3a283f8928a",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/10037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10037.jpg"
+            "imagesrc": "/images/cards/en/10037.jpg"
         },
         {
             "last-modified": "2015-10-06T21:28:40+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "59fba6dd-ae8f-4369-9596-1b6a44e6685e",
             "value": "Clubs9",
             "url": "https://dtdb.co/en/card/10038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10038.jpg"
+            "imagesrc": "/images/cards/en/10038.jpg"
         },
         {
             "last-modified": "2015-10-11T17:17:54+02:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "ea2b5db4-659a-4524-8ca3-e84ae8d1f9b5",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/10039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10039.jpg"
+            "imagesrc": "/images/cards/en/10039.jpg"
         },
         {
             "last-modified": "2015-10-02T18:17:15+02:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "e5aa241d-bc8c-46ee-a250-dac44616415e",
             "value": "",
             "url": "https://dtdb.co/en/card/10040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10040.jpg"
+            "imagesrc": "/images/cards/en/10040.jpg"
         },
         {
             "last-modified": "2015-10-06T20:07:37+02:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "c8311233-937c-4468-89f1-8c667ced576b",
             "value": "",
             "url": "https://dtdb.co/en/card/10041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/10041.jpg"
+            "imagesrc": "/images/cards/en/10041.jpg"
         }
     ]
 }

--- a/packs/TSs.json
+++ b/packs/TSs.json
@@ -39,7 +39,7 @@
             "octgnid": "f23323c6-2381-4f8a-961c-606f84147c56",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/17001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17001.jpg"
+            "imagesrc": "/images/cards/en/17001.jpg"
         },
         {
             "last-modified": "2016-08-06T22:07:54+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "32e3dc80-38a5-41e5-a267-f5b0f3a55d22",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/17002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17002.jpg"
+            "imagesrc": "/images/cards/en/17002.jpg"
         },
         {
             "last-modified": "2016-08-06T22:09:14+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "ea7a82ee-ad0d-4508-bbd7-a0a7b9fd610a",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/17003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17003.jpg"
+            "imagesrc": "/images/cards/en/17003.jpg"
         },
         {
             "last-modified": "2016-08-06T22:10:42+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "1bea3954-dab3-42ef-830d-4d03a779b7b6",
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/17004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17004.jpg"
+            "imagesrc": "/images/cards/en/17004.jpg"
         },
         {
             "last-modified": "2016-08-06T22:11:53+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "5f270369-68b9-4ce9-9e67-1e74f313ea6f",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/17005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17005.jpg"
+            "imagesrc": "/images/cards/en/17005.jpg"
         },
         {
             "last-modified": "2016-08-06T22:13:42+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "b66bd108-b7f4-4eb4-8dab-bdcf67dab50c",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/17006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17006.jpg"
+            "imagesrc": "/images/cards/en/17006.jpg"
         },
         {
             "last-modified": "2017-12-06T17:13:35+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "96ac4bcb-e022-4dc3-b87f-a9a0ddc4c723",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/17007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17007.jpg"
+            "imagesrc": "/images/cards/en/17007.jpg"
         },
         {
             "last-modified": "2016-08-06T22:16:57+02:00",
@@ -270,7 +270,7 @@
             "octgnid": "4e724dee-6a9f-42dc-92ee-00e0f55be29f",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/17008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17008.jpg"
+            "imagesrc": "/images/cards/en/17008.jpg"
         },
         {
             "last-modified": "2016-08-06T22:18:18+02:00",
@@ -303,7 +303,7 @@
             "octgnid": "49e72f76-4b92-468d-90c9-325689b607b1",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/17009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17009.jpg"
+            "imagesrc": "/images/cards/en/17009.jpg"
         },
         {
             "last-modified": "2016-08-06T22:19:33+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "576ef086-4950-47b3-8ab5-71f3fdbce794",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/17010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17010.jpg"
+            "imagesrc": "/images/cards/en/17010.jpg"
         },
         {
             "last-modified": "2016-08-06T22:20:15+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "ef1b01c0-82e5-4243-8839-2136df14d4b1",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/17011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17011.jpg"
+            "imagesrc": "/images/cards/en/17011.jpg"
         },
         {
             "last-modified": "2017-12-06T17:14:07+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "92cf4c1a-cd1b-4377-a0dd-e06d52edbbff",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/17012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17012.jpg"
+            "imagesrc": "/images/cards/en/17012.jpg"
         },
         {
             "last-modified": "2016-08-06T22:22:03+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "66f1e08f-2b5a-4e3e-97d2-0289c6379700",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/17013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17013.jpg"
+            "imagesrc": "/images/cards/en/17013.jpg"
         },
         {
             "last-modified": "2017-12-06T17:15:00+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "b63cda5e-d4cb-436f-be79-79dc74124a57",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/17014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17014.jpg"
+            "imagesrc": "/images/cards/en/17014.jpg"
         },
         {
             "last-modified": "2016-08-06T22:24:36+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "fac96abf-efee-492f-ae9e-72a944e518a6",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/17015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17015.jpg"
+            "imagesrc": "/images/cards/en/17015.jpg"
         },
         {
             "last-modified": "2016-08-06T22:25:16+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "f5359fcb-0095-4ef0-8264-e3eec905528d",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/17016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17016.jpg"
+            "imagesrc": "/images/cards/en/17016.jpg"
         },
         {
             "last-modified": "2016-08-06T22:26:01+02:00",
@@ -567,7 +567,7 @@
             "octgnid": "7469036b-d154-4cb5-9eff-7d77fbdbcdf0",
             "value": "Hearts12",
             "url": "https://dtdb.co/en/card/17017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17017.jpg"
+            "imagesrc": "/images/cards/en/17017.jpg"
         },
         {
             "last-modified": "2016-08-06T22:27:15+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "4bc332e3-b672-4445-90af-f4b7e4816fee",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/17018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17018.jpg"
+            "imagesrc": "/images/cards/en/17018.jpg"
         },
         {
             "last-modified": "2016-08-06T22:28:30+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "722d4849-79a2-4bf3-b3d6-109de8762773",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/17019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17019.jpg"
+            "imagesrc": "/images/cards/en/17019.jpg"
         },
         {
             "last-modified": "2016-08-06T22:29:09+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "d67fe646-d457-41bd-b8ce-ec8f836ca3a5",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/17020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17020.jpg"
+            "imagesrc": "/images/cards/en/17020.jpg"
         },
         {
             "last-modified": "2016-08-06T22:30:07+02:00",
@@ -699,7 +699,7 @@
             "octgnid": "22e8401c-bf60-42e0-8119-36ce05c5d893",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/17021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/17021.jpg"
+            "imagesrc": "/images/cards/en/17021.jpg"
         }
     ]
 }

--- a/packs/W2D.json
+++ b/packs/W2D.json
@@ -39,7 +39,7 @@
             "octgnid": "F92310E9-2EF0-E0F5-F6BD-8AB6FF120396\n",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/23001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23001.jpg"
+            "imagesrc": "/images/cards/en/23001.jpg"
         },
         {
             "last-modified": "2020-12-25T04:58:28+01:00",
@@ -72,7 +72,7 @@
             "octgnid": "165D10F2-BC2A-4F22-EC82-00E85C2BB283\n",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/23002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23002.jpg"
+            "imagesrc": "/images/cards/en/23002.jpg"
         },
         {
             "last-modified": "2020-09-22T00:55:43+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "7917E2E5-6155-16A3-10F3-67A9B5566FDB",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/23003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23003.jpg"
+            "imagesrc": "/images/cards/en/23003.jpg"
         },
         {
             "last-modified": "2020-12-25T07:01:11+01:00",
@@ -138,7 +138,7 @@
             "octgnid": "ACD35B70-FEF5-F8EF-DAFC-1C50933CB85D\n",
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/23004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23004.jpg"
+            "imagesrc": "/images/cards/en/23004.jpg"
         },
         {
             "last-modified": "2020-09-22T00:55:24+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "ACE5F009-2377-6E35-3F48-E8A7F87F72AF\n",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/23005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23005.jpg"
+            "imagesrc": "/images/cards/en/23005.jpg"
         },
         {
             "last-modified": "2020-12-25T05:02:05+01:00",
@@ -204,7 +204,7 @@
             "octgnid": "23893F82-0BF3-E093-95CD-91DC43121179\n",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/23006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23006.jpg"
+            "imagesrc": "/images/cards/en/23006.jpg"
         },
         {
             "last-modified": "2020-12-25T05:04:12+01:00",
@@ -237,7 +237,7 @@
             "octgnid": "1DF76E4D-4178-02E1-CAEB-A76C06E0B34E\n",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/23007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23007.jpg"
+            "imagesrc": "/images/cards/en/23007.jpg"
         },
         {
             "last-modified": "2020-12-25T05:05:54+01:00",
@@ -270,7 +270,7 @@
             "octgnid": "cd76cc0e-0390-4fca-fc93-1d5b3ba65048\n",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/23008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23008.jpg"
+            "imagesrc": "/images/cards/en/23008.jpg"
         },
         {
             "last-modified": "2020-12-25T05:08:22+01:00",
@@ -303,7 +303,7 @@
             "octgnid": "70479907-69CD-DE1A-BE32-86B2B48DC6FE\n",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/23009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23009.jpg"
+            "imagesrc": "/images/cards/en/23009.jpg"
         },
         {
             "last-modified": "2020-12-25T05:09:57+01:00",
@@ -336,7 +336,7 @@
             "octgnid": "377CCEBD-2C23-05F9-498A-8F3B1A02CBB6\n",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/23010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23010.jpg"
+            "imagesrc": "/images/cards/en/23010.jpg"
         },
         {
             "last-modified": "2020-09-22T00:55:14+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "9BF10098-29D7-40BA-2F51-4461062E822E\n",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/23011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23011.jpg"
+            "imagesrc": "/images/cards/en/23011.jpg"
         },
         {
             "last-modified": "2020-12-25T05:12:08+01:00",
@@ -402,7 +402,7 @@
             "octgnid": "0FBD307A-D4A2-05E6-4D29-C8B665683066",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/23012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23012.jpg"
+            "imagesrc": "/images/cards/en/23012.jpg"
         },
         {
             "last-modified": "2020-12-25T05:14:11+01:00",
@@ -435,7 +435,7 @@
             "octgnid": "A1FC8CE3-4E29-ACF6-9390-80CA1679AE12\n",
             "value": "Spades2",
             "url": "https://dtdb.co/en/card/23013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23013.jpg"
+            "imagesrc": "/images/cards/en/23013.jpg"
         },
         {
             "last-modified": "2020-12-25T07:03:35+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "193BD6A0-D120-CB58-D562-DE5707C9E982\n",
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/23014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23014.jpg"
+            "imagesrc": "/images/cards/en/23014.jpg"
         },
         {
             "last-modified": "2020-12-25T05:16:41+01:00",
@@ -501,7 +501,7 @@
             "octgnid": "AC4EA292-CBF6-C502-0F1D-B677636BDE47\n",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/23015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23015.jpg"
+            "imagesrc": "/images/cards/en/23015.jpg"
         },
         {
             "last-modified": "2020-12-25T05:17:51+01:00",
@@ -534,7 +534,7 @@
             "octgnid": "F3C039D3-EBF4-0D99-4541-7B5DA89262C6\n",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/23016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23016.jpg"
+            "imagesrc": "/images/cards/en/23016.jpg"
         },
         {
             "last-modified": "2020-12-25T05:45:07+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "F87A0195-7757-9AA2-2875-0AE73F4EC6B8\n",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/23017",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23017.jpg"
+            "imagesrc": "/images/cards/en/23017.jpg"
         },
         {
             "last-modified": "2020-09-22T00:55:03+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "F1FD3556-4D53-2941-E3A2-69851ECF7FDE\n",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/23018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23018.jpg"
+            "imagesrc": "/images/cards/en/23018.jpg"
         },
         {
             "last-modified": "2020-12-25T05:46:55+01:00",
@@ -633,7 +633,7 @@
             "octgnid": "AAD95A53-2961-ED18-535D-494554E06425\n",
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/23019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23019.jpg"
+            "imagesrc": "/images/cards/en/23019.jpg"
         },
         {
             "last-modified": "2020-12-25T05:48:42+01:00",
@@ -666,7 +666,7 @@
             "octgnid": "4C0B90C2-A605-AB0B-A449-46F823BFA1BC\n",
             "value": "Spades11",
             "url": "https://dtdb.co/en/card/23020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23020.jpg"
+            "imagesrc": "/images/cards/en/23020.jpg"
         },
         {
             "last-modified": "2020-12-25T05:50:13+01:00",
@@ -699,7 +699,7 @@
             "octgnid": "E4CD7B8F-066B-476B-EA81-D0F582A15F68\n",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/23021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23021.jpg"
+            "imagesrc": "/images/cards/en/23021.jpg"
         },
         {
             "last-modified": "2020-09-22T00:54:52+02:00",
@@ -732,7 +732,7 @@
             "octgnid": "DACF7490-BFF1-34B6-6C37-BD25C823E4CB",
             "value": "Spades4",
             "url": "https://dtdb.co/en/card/23022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23022.jpg"
+            "imagesrc": "/images/cards/en/23022.jpg"
         },
         {
             "last-modified": "2020-12-25T05:52:07+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "ED1B1A7D-CAD1-5E36-92EF-113B8F6B6E5A\n",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/23023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23023.jpg"
+            "imagesrc": "/images/cards/en/23023.jpg"
         },
         {
             "last-modified": "2020-09-22T00:54:36+02:00",
@@ -798,7 +798,7 @@
             "octgnid": "2FC8AC10-3918-2213-B9FB-9AD0D4BC83F9",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/23024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23024.jpg"
+            "imagesrc": "/images/cards/en/23024.jpg"
         },
         {
             "last-modified": "2020-12-25T05:54:06+01:00",
@@ -831,7 +831,7 @@
             "octgnid": "D1814157-4464-C071-CBA9-D53B565A3C80\n",
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/23025",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23025.jpg"
+            "imagesrc": "/images/cards/en/23025.jpg"
         },
         {
             "last-modified": "2020-12-25T05:56:37+01:00",
@@ -864,7 +864,7 @@
             "octgnid": "C1023D9F-B2EC-0DBA-CCED-F28E480D7914\n",
             "value": "Spades5",
             "url": "https://dtdb.co/en/card/23026",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23026.jpg"
+            "imagesrc": "/images/cards/en/23026.jpg"
         },
         {
             "last-modified": "2021-01-05T01:19:46+01:00",
@@ -897,7 +897,7 @@
             "octgnid": "E1917BC9-2145-3C06-0535-2414D542F995\n",
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/23027",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23027.jpg"
+            "imagesrc": "/images/cards/en/23027.jpg"
         },
         {
             "last-modified": "2020-12-25T05:59:46+01:00",
@@ -930,7 +930,7 @@
             "octgnid": "1A882871-8071-A72E-7215-7C11639CFF43\n",
             "value": "Spades9",
             "url": "https://dtdb.co/en/card/23028",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23028.jpg"
+            "imagesrc": "/images/cards/en/23028.jpg"
         },
         {
             "last-modified": "2020-12-26T18:48:43+01:00",
@@ -963,7 +963,7 @@
             "octgnid": "3EF8B7AF-D65A-6468-8DFD-B4ABF43E8B75\n",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/23029",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23029.jpg"
+            "imagesrc": "/images/cards/en/23029.jpg"
         },
         {
             "last-modified": "2020-09-22T00:54:26+02:00",
@@ -996,7 +996,7 @@
             "octgnid": "4C98FC02-ACBF-C049-9034-48ADFEA74251",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/23030",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23030.jpg"
+            "imagesrc": "/images/cards/en/23030.jpg"
         },
         {
             "last-modified": "2020-09-22T00:54:14+02:00",
@@ -1029,7 +1029,7 @@
             "octgnid": "1F754146-A202-FA7C-9806-0EFDA83C2B5F\n",
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/23031",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23031.jpg"
+            "imagesrc": "/images/cards/en/23031.jpg"
         },
         {
             "last-modified": "2020-12-25T06:04:23+01:00",
@@ -1062,7 +1062,7 @@
             "octgnid": "764C8995-7425-4D62-6DC4-EAD649A52C10\n",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/23032",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23032.jpg"
+            "imagesrc": "/images/cards/en/23032.jpg"
         },
         {
             "last-modified": "2020-09-22T00:54:04+02:00",
@@ -1095,7 +1095,7 @@
             "octgnid": "90059DCE-A180-A807-A370-B2D498669C7A\n",
             "value": "Diams6",
             "url": "https://dtdb.co/en/card/23033",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23033.jpg"
+            "imagesrc": "/images/cards/en/23033.jpg"
         },
         {
             "last-modified": "2020-12-25T06:05:51+01:00",
@@ -1128,7 +1128,7 @@
             "octgnid": "7F0F107B-72C4-09AD-1FC2-1C3C9D527EA3\n",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/23034",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23034.jpg"
+            "imagesrc": "/images/cards/en/23034.jpg"
         },
         {
             "last-modified": "2020-12-26T18:48:58+01:00",
@@ -1161,7 +1161,7 @@
             "octgnid": "267714DC-8B1C-0DA2-1888-3F4BA1DA90A4\n",
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/23035",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23035.jpg"
+            "imagesrc": "/images/cards/en/23035.jpg"
         },
         {
             "last-modified": "2020-12-25T06:08:38+01:00",
@@ -1194,7 +1194,7 @@
             "octgnid": "CBBCBCB0-DFFF-4F0C-D519-401B4451AC74\n",
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/23036",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23036.jpg"
+            "imagesrc": "/images/cards/en/23036.jpg"
         },
         {
             "last-modified": "2020-09-22T00:53:52+02:00",
@@ -1227,7 +1227,7 @@
             "octgnid": "97503D43-A3B3-8D2D-8AE6-EB90A79737FE\n",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/23037",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23037.jpg"
+            "imagesrc": "/images/cards/en/23037.jpg"
         },
         {
             "last-modified": "2020-12-25T06:10:04+01:00",
@@ -1260,7 +1260,7 @@
             "octgnid": "A3F5074F-F214-F8FA-4762-CEB5E24C25BF\n",
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/23038",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23038.jpg"
+            "imagesrc": "/images/cards/en/23038.jpg"
         },
         {
             "last-modified": "2020-12-25T06:11:12+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": "389C1CAB-AF96-F57E-870C-ABF5DE083C32\n",
             "value": "Hearts9",
             "url": "https://dtdb.co/en/card/23039",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23039.jpg"
+            "imagesrc": "/images/cards/en/23039.jpg"
         },
         {
             "last-modified": "2020-12-25T06:12:50+01:00",
@@ -1326,7 +1326,7 @@
             "octgnid": "077072DB-C333-E4DE-62C5-9C1547A137C7\n",
             "value": "Hearts13",
             "url": "https://dtdb.co/en/card/23040",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23040.jpg"
+            "imagesrc": "/images/cards/en/23040.jpg"
         },
         {
             "last-modified": "2020-12-25T06:38:08+01:00",
@@ -1359,7 +1359,7 @@
             "octgnid": "446B56B5-5E3D-DA1B-28AF-7948A194C1E5\n",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/23041",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23041.jpg"
+            "imagesrc": "/images/cards/en/23041.jpg"
         },
         {
             "last-modified": "2020-12-25T06:39:13+01:00",
@@ -1392,7 +1392,7 @@
             "octgnid": "25FB9EC5-3A7B-5A36-BE52-F8D063F9090E\n",
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/23042",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23042.jpg"
+            "imagesrc": "/images/cards/en/23042.jpg"
         },
         {
             "last-modified": "2020-12-25T06:40:40+01:00",
@@ -1425,7 +1425,7 @@
             "octgnid": "8DB59195-8D4B-636D-EC75-485C0C4C81EE\n",
             "value": "Hearts2",
             "url": "https://dtdb.co/en/card/23043",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23043.jpg"
+            "imagesrc": "/images/cards/en/23043.jpg"
         },
         {
             "last-modified": "2020-12-25T06:42:22+01:00",
@@ -1458,7 +1458,7 @@
             "octgnid": "22F9EACA-E043-D07C-8679-BF17A1C990C2\n",
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/23044",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23044.jpg"
+            "imagesrc": "/images/cards/en/23044.jpg"
         },
         {
             "last-modified": "2020-12-25T06:43:28+01:00",
@@ -1491,7 +1491,7 @@
             "octgnid": "B636E8A0-6691-AE46-7965-C14ABDE2BD96\n",
             "value": "Hearts6",
             "url": "https://dtdb.co/en/card/23045",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23045.jpg"
+            "imagesrc": "/images/cards/en/23045.jpg"
         },
         {
             "last-modified": "2020-12-25T06:45:51+01:00",
@@ -1524,7 +1524,7 @@
             "octgnid": "4C7E01AC-9277-4F11-8B82-2CEB53B69FFC\n",
             "value": "Hearts11",
             "url": "https://dtdb.co/en/card/23046",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23046.jpg"
+            "imagesrc": "/images/cards/en/23046.jpg"
         },
         {
             "last-modified": "2020-12-25T06:47:03+01:00",
@@ -1557,7 +1557,7 @@
             "octgnid": "887C80E4-FDF6-59F9-BEA4-8E26623BF9BF\n",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/23047",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23047.jpg"
+            "imagesrc": "/images/cards/en/23047.jpg"
         },
         {
             "last-modified": "2020-12-25T06:48:22+01:00",
@@ -1590,7 +1590,7 @@
             "octgnid": "92621DD3-8DA3-CC58-042A-9E3ACE6B5303\n",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/23048",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23048.jpg"
+            "imagesrc": "/images/cards/en/23048.jpg"
         },
         {
             "last-modified": "2020-12-25T06:49:39+01:00",
@@ -1623,7 +1623,7 @@
             "octgnid": "FF5B9022-2B62-9772-30D7-E51D009AFF7E\n",
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/23049",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23049.jpg"
+            "imagesrc": "/images/cards/en/23049.jpg"
         },
         {
             "last-modified": "2020-12-25T06:50:54+01:00",
@@ -1656,7 +1656,7 @@
             "octgnid": "466E2763-D160-F31F-87E6-9D1101BF776F\n",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/23050",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23050.jpg"
+            "imagesrc": "/images/cards/en/23050.jpg"
         },
         {
             "last-modified": "2020-12-25T06:52:11+01:00",
@@ -1689,7 +1689,7 @@
             "octgnid": "DA2A0D86-A4AC-F4E2-57D6-43E86E3F9D16\n",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/23051",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23051.jpg"
+            "imagesrc": "/images/cards/en/23051.jpg"
         },
         {
             "last-modified": "2020-12-25T06:53:30+01:00",
@@ -1722,7 +1722,7 @@
             "octgnid": "586E256A-2F1E-25E2-B2DC-0B6653FE2ABC\n",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/23052",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23052.jpg"
+            "imagesrc": "/images/cards/en/23052.jpg"
         },
         {
             "last-modified": "2020-12-25T06:54:51+01:00",
@@ -1755,7 +1755,7 @@
             "octgnid": "677CA7E8-C3A0-FA9A-70DE-2C8BDD11B5CD\n",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/23053",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23053.jpg"
+            "imagesrc": "/images/cards/en/23053.jpg"
         },
         {
             "last-modified": "2020-12-25T06:56:26+01:00",
@@ -1788,7 +1788,7 @@
             "octgnid": "49661367-01CC-BBFF-F3F6-223859E7A0BF\n",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/23054",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23054.jpg"
+            "imagesrc": "/images/cards/en/23054.jpg"
         },
         {
             "last-modified": "2020-12-25T06:57:32+01:00",
@@ -1821,7 +1821,7 @@
             "octgnid": "F68F6ED8-BDB8-1A9B-315E-975A2FF35249\n",
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/23055",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23055.jpg"
+            "imagesrc": "/images/cards/en/23055.jpg"
         },
         {
             "last-modified": "2020-12-25T06:58:50+01:00",
@@ -1854,7 +1854,7 @@
             "octgnid": "7F445083-EB31-202B-81D7-FFC2DC41B8DE\n",
             "value": "Clubs11",
             "url": "https://dtdb.co/en/card/23056",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/23056.jpg"
+            "imagesrc": "/images/cards/en/23056.jpg"
         }
     ]
 }

--- a/packs/alt.json
+++ b/packs/alt.json
@@ -39,7 +39,7 @@
             "octgnid": "1536769f-42f4-4840-9360-96d2e7e3f366",
             "value": "Clubs5",
             "url": "https://dtdb.co/en/card/00001",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00001.jpg"
+            "imagesrc": "/images/cards/en/00001.jpg"
         },
         {
             "last-modified": "2018-04-24T00:41:55+02:00",
@@ -72,7 +72,7 @@
             "octgnid": "a9b3a2b8-9f22-474d-b35a-59a380c0921f",
             "value": "Diams1",
             "url": "https://dtdb.co/en/card/00002",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00002.jpg"
+            "imagesrc": "/images/cards/en/00002.jpg"
         },
         {
             "last-modified": "2018-04-24T00:43:32+02:00",
@@ -105,7 +105,7 @@
             "octgnid": "8649f082-f7cd-414d-b360-9b1b72f6172b",
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/00003",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00003.jpg"
+            "imagesrc": "/images/cards/en/00003.jpg"
         },
         {
             "last-modified": "2018-04-24T00:42:16+02:00",
@@ -138,7 +138,7 @@
             "octgnid": "ec741b63-8ac4-4b5a-9767-9854e05b91c3",
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/00004",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00004.jpg"
+            "imagesrc": "/images/cards/en/00004.jpg"
         },
         {
             "last-modified": "2018-04-24T00:44:08+02:00",
@@ -171,7 +171,7 @@
             "octgnid": "1950bc30-abf5-4ed4-b20a-e56bb4032de0",
             "value": "Clubs6",
             "url": "https://dtdb.co/en/card/00005",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00005.jpg"
+            "imagesrc": "/images/cards/en/00005.jpg"
         },
         {
             "last-modified": "2018-04-24T00:43:14+02:00",
@@ -204,7 +204,7 @@
             "octgnid": "6560b478-c5fe-4717-a2d1-40ef7c6effa6",
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/00006",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00006.jpg"
+            "imagesrc": "/images/cards/en/00006.jpg"
         },
         {
             "last-modified": "2018-04-24T00:44:31+02:00",
@@ -237,7 +237,7 @@
             "octgnid": "335662d9-0d7c-430e-a556-11693385f5aa",
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/00007",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00007.jpg"
+            "imagesrc": "/images/cards/en/00007.jpg"
         },
         {
             "last-modified": "2017-10-24T03:35:03+02:00",
@@ -270,7 +270,7 @@
             "octgnid": null,
             "value": "Clubs10",
             "url": "https://dtdb.co/en/card/00008",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00008.jpg"
+            "imagesrc": "/images/cards/en/00008.jpg"
         },
         {
             "last-modified": "2017-10-24T03:35:13+02:00",
@@ -303,7 +303,7 @@
             "octgnid": null,
             "value": "Diams4",
             "url": "https://dtdb.co/en/card/00009",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00009.jpg"
+            "imagesrc": "/images/cards/en/00009.jpg"
         },
         {
             "last-modified": "2017-10-24T03:35:36+02:00",
@@ -336,7 +336,7 @@
             "octgnid": "a23d36e0-8231-49e7-bbc4-4e56c179b045",
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/00010",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00010.jpg"
+            "imagesrc": "/images/cards/en/00010.jpg"
         },
         {
             "last-modified": "2017-10-24T03:36:05+02:00",
@@ -369,7 +369,7 @@
             "octgnid": "b999405d-e2ca-4703-beda-67f9697fc977",
             "value": "Diams3",
             "url": "https://dtdb.co/en/card/00011",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00011.jpg"
+            "imagesrc": "/images/cards/en/00011.jpg"
         },
         {
             "last-modified": "2018-04-24T01:00:04+02:00",
@@ -402,7 +402,7 @@
             "octgnid": "d7e770dd-793f-4a53-a404-e3873a762ad1",
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/00012",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00012.jpg"
+            "imagesrc": "/images/cards/en/00012.jpg"
         },
         {
             "last-modified": "2018-04-24T01:02:07+02:00",
@@ -435,7 +435,7 @@
             "octgnid": "9aa68e21-1eee-4d44-993e-dd8cf60ed613",
             "value": "Hearts5",
             "url": "https://dtdb.co/en/card/00013",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00013.jpg"
+            "imagesrc": "/images/cards/en/00013.jpg"
         },
         {
             "last-modified": "2017-12-13T13:27:40+01:00",
@@ -468,7 +468,7 @@
             "octgnid": "28d66d3e-bc96-4c2c-9ebb-38dfabceb440",
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/00014",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00014.jpg"
+            "imagesrc": "/images/cards/en/00014.jpg"
         },
         {
             "last-modified": "2017-10-24T03:34:40+02:00",
@@ -501,7 +501,7 @@
             "octgnid": "bf1c8173-843a-4a20-be3b-f4ae650cfdd2",
             "value": "Hearts1",
             "url": "https://dtdb.co/en/card/00015",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00015.jpg"
+            "imagesrc": "/images/cards/en/00015.jpg"
         },
         {
             "last-modified": "2018-04-24T00:44:49+02:00",
@@ -534,7 +534,7 @@
             "octgnid": "a630aa27-9ba9-4e38-86b4-83cade3a7546",
             "value": "",
             "url": "https://dtdb.co/en/card/00016",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00016.jpg"
+            "imagesrc": "/images/cards/en/00016.jpg"
         },
         {
             "last-modified": "2017-12-13T13:25:40+01:00",
@@ -567,7 +567,7 @@
             "octgnid": "0c41f0c4-2491-4723-8cf9-d8ab3e071e05",
             "value": "Clubs4",
             "url": "https://dtdb.co/en/card/00018",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00018.jpg"
+            "imagesrc": "/images/cards/en/00018.jpg"
         },
         {
             "last-modified": "2017-10-24T03:36:38+02:00",
@@ -600,7 +600,7 @@
             "octgnid": "2ad321e1-eaa0-4984-bdd0-a8d088045588",
             "value": "Diams7",
             "url": "https://dtdb.co/en/card/00019",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00019.jpg"
+            "imagesrc": "/images/cards/en/00019.jpg"
         },
         {
             "last-modified": "2017-10-24T04:01:05+02:00",
@@ -633,7 +633,7 @@
             "octgnid": "e11367a5-6fad-40a4-b22a-a2571eb7c330",
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/00020",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00020.jpg"
+            "imagesrc": "/images/cards/en/00020.jpg"
         },
         {
             "last-modified": "2017-10-24T04:09:08+02:00",
@@ -666,7 +666,7 @@
             "octgnid": "57528427-b65a-4056-9fea-082bba8ef4a9",
             "value": "Diams5",
             "url": "https://dtdb.co/en/card/00021",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00021.jpg"
+            "imagesrc": "/images/cards/en/00021.jpg"
         },
         {
             "last-modified": "2017-10-24T03:59:59+02:00",
@@ -699,7 +699,7 @@
             "octgnid": null,
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/00022",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00022.jpg"
+            "imagesrc": "/images/cards/en/00022.jpg"
         },
         {
             "last-modified": "2017-10-24T04:01:21+02:00",
@@ -732,7 +732,7 @@
             "octgnid": null,
             "value": "Diams10",
             "url": "https://dtdb.co/en/card/00023",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00023.jpg"
+            "imagesrc": "/images/cards/en/00023.jpg"
         },
         {
             "last-modified": "2017-12-13T13:24:25+01:00",
@@ -765,7 +765,7 @@
             "octgnid": "36c80330-39fc-4fdc-8736-4c8d47758063",
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/00024",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00024.jpg"
+            "imagesrc": "/images/cards/en/00024.jpg"
         },
         {
             "last-modified": "2016-02-02T20:43:20+01:00",
@@ -798,7 +798,7 @@
             "octgnid": null,
             "value": "Spades3",
             "url": "https://dtdb.co/en/card/00098",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00098.jpg"
+            "imagesrc": "/images/cards/en/00098.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:49+02:00",
@@ -831,7 +831,7 @@
             "octgnid": null,
             "value": "Spades1",
             "url": "https://dtdb.co/en/card/00099",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00099.jpg"
+            "imagesrc": "/images/cards/en/00099.jpg"
         },
         {
             "last-modified": "2015-10-02T20:23:26+02:00",
@@ -864,7 +864,7 @@
             "octgnid": null,
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/00100",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00100.jpg"
+            "imagesrc": "/images/cards/en/00100.jpg"
         },
         {
             "last-modified": "2017-11-05T04:48:08+01:00",
@@ -897,7 +897,7 @@
             "octgnid": null,
             "value": "Spades7",
             "url": "https://dtdb.co/en/card/00101",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00101.jpg"
+            "imagesrc": "/images/cards/en/00101.jpg"
         },
         {
             "last-modified": "2017-11-05T04:47:34+01:00",
@@ -930,7 +930,7 @@
             "octgnid": null,
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/00102",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00102.jpg"
+            "imagesrc": "/images/cards/en/00102.jpg"
         },
         {
             "last-modified": "2017-11-07T04:57:41+01:00",
@@ -963,7 +963,7 @@
             "octgnid": null,
             "value": "Hearts8",
             "url": "https://dtdb.co/en/card/00103",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00103.jpg"
+            "imagesrc": "/images/cards/en/00103.jpg"
         },
         {
             "last-modified": "2017-11-07T05:00:24+01:00",
@@ -996,7 +996,7 @@
             "octgnid": null,
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/00104",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00104.jpg"
+            "imagesrc": "/images/cards/en/00104.jpg"
         },
         {
             "last-modified": "2017-11-07T05:04:54+01:00",
@@ -1029,7 +1029,7 @@
             "octgnid": null,
             "value": "Spades13",
             "url": "https://dtdb.co/en/card/00105",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00105.jpg"
+            "imagesrc": "/images/cards/en/00105.jpg"
         },
         {
             "last-modified": "2017-11-07T05:08:14+01:00",
@@ -1062,7 +1062,7 @@
             "octgnid": null,
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/00106",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00106.jpg"
+            "imagesrc": "/images/cards/en/00106.jpg"
         },
         {
             "last-modified": "2017-11-07T05:11:22+01:00",
@@ -1095,7 +1095,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00107",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00107.jpg"
+            "imagesrc": "/images/cards/en/00107.jpg"
         },
         {
             "last-modified": "2017-11-07T05:12:38+01:00",
@@ -1128,7 +1128,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00108",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00108.jpg"
+            "imagesrc": "/images/cards/en/00108.jpg"
         },
         {
             "last-modified": "2017-11-07T05:13:19+01:00",
@@ -1161,7 +1161,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00109",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00109.jpg"
+            "imagesrc": "/images/cards/en/00109.jpg"
         },
         {
             "last-modified": "2017-11-07T05:19:29+01:00",
@@ -1194,7 +1194,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00110",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00110.jpg"
+            "imagesrc": "/images/cards/en/00110.jpg"
         },
         {
             "last-modified": "2015-11-14T19:59:06+01:00",
@@ -1227,7 +1227,7 @@
             "octgnid": null,
             "value": "Clubs8",
             "url": "https://dtdb.co/en/card/00111",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00111.jpg"
+            "imagesrc": "/images/cards/en/00111.jpg"
         },
         {
             "last-modified": "2018-05-08T03:11:25+02:00",
@@ -1260,7 +1260,7 @@
             "octgnid": null,
             "value": "Clubs13",
             "url": "https://dtdb.co/en/card/00112",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00112.jpg"
+            "imagesrc": "/images/cards/en/00112.jpg"
         },
         {
             "last-modified": "2017-11-07T05:18:04+01:00",
@@ -1293,7 +1293,7 @@
             "octgnid": null,
             "value": "Spades10",
             "url": "https://dtdb.co/en/card/00113",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00113.jpg"
+            "imagesrc": "/images/cards/en/00113.jpg"
         },
         {
             "last-modified": "2017-11-07T05:21:50+01:00",
@@ -1326,7 +1326,7 @@
             "octgnid": null,
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/00114",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00114.jpg"
+            "imagesrc": "/images/cards/en/00114.jpg"
         },
         {
             "last-modified": "2017-11-07T05:24:07+01:00",
@@ -1359,7 +1359,7 @@
             "octgnid": null,
             "value": "Clubs2",
             "url": "https://dtdb.co/en/card/00115",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00115.jpg"
+            "imagesrc": "/images/cards/en/00115.jpg"
         },
         {
             "last-modified": "2017-11-07T05:26:52+01:00",
@@ -1392,7 +1392,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00116",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00116.jpg"
+            "imagesrc": "/images/cards/en/00116.jpg"
         },
         {
             "last-modified": "2017-11-07T05:29:36+01:00",
@@ -1425,7 +1425,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00117",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00117.jpg"
+            "imagesrc": "/images/cards/en/00117.jpg"
         },
         {
             "last-modified": "2017-11-08T03:07:20+01:00",
@@ -1458,7 +1458,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00118",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00118.jpg"
+            "imagesrc": "/images/cards/en/00118.jpg"
         },
         {
             "last-modified": "2017-11-08T03:08:58+01:00",
@@ -1491,7 +1491,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00119",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00119.jpg"
+            "imagesrc": "/images/cards/en/00119.jpg"
         },
         {
             "last-modified": "2017-11-08T03:12:20+01:00",
@@ -1524,7 +1524,7 @@
             "octgnid": null,
             "value": "Diams11",
             "url": "https://dtdb.co/en/card/00120",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00120.jpg"
+            "imagesrc": "/images/cards/en/00120.jpg"
         },
         {
             "last-modified": "2017-11-08T23:02:01+01:00",
@@ -1557,7 +1557,7 @@
             "octgnid": null,
             "value": "Hearts4",
             "url": "https://dtdb.co/en/card/00121",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00121.jpg"
+            "imagesrc": "/images/cards/en/00121.jpg"
         },
         {
             "last-modified": "2016-02-02T20:15:50+01:00",
@@ -1590,7 +1590,7 @@
             "octgnid": null,
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/00122",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00122.jpg"
+            "imagesrc": "/images/cards/en/00122.jpg"
         },
         {
             "last-modified": "2015-11-14T21:30:11+01:00",
@@ -1623,7 +1623,7 @@
             "octgnid": null,
             "value": "Diams12",
             "url": "https://dtdb.co/en/card/00123",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00123.jpg"
+            "imagesrc": "/images/cards/en/00123.jpg"
         },
         {
             "last-modified": "2015-11-14T21:55:27+01:00",
@@ -1656,7 +1656,7 @@
             "octgnid": null,
             "value": "Hearts3",
             "url": "https://dtdb.co/en/card/00124",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00124.jpg"
+            "imagesrc": "/images/cards/en/00124.jpg"
         },
         {
             "last-modified": "2017-10-24T03:34:50+02:00",
@@ -1689,7 +1689,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00125",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00125.jpg"
+            "imagesrc": "/images/cards/en/00125.jpg"
         },
         {
             "last-modified": "2017-11-16T18:36:06+01:00",
@@ -1722,7 +1722,7 @@
             "octgnid": null,
             "value": "",
             "url": "https://dtdb.co/en/card/00126",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00126.jpg"
+            "imagesrc": "/images/cards/en/00126.jpg"
         },
         {
             "last-modified": "2015-11-14T19:51:48+01:00",
@@ -1755,7 +1755,7 @@
             "octgnid": null,
             "value": "Hearts10",
             "url": "https://dtdb.co/en/card/00127",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00127.jpg"
+            "imagesrc": "/images/cards/en/00127.jpg"
         },
         {
             "last-modified": "2017-11-16T18:40:02+01:00",
@@ -1788,7 +1788,7 @@
             "octgnid": null,
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/00128",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00128.jpg"
+            "imagesrc": "/images/cards/en/00128.jpg"
         },
         {
             "last-modified": "2015-11-14T21:57:11+01:00",
@@ -1821,7 +1821,7 @@
             "octgnid": null,
             "value": "Spades8",
             "url": "https://dtdb.co/en/card/00129",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00129.jpg"
+            "imagesrc": "/images/cards/en/00129.jpg"
         },
         {
             "last-modified": "2015-11-14T21:31:51+01:00",
@@ -1854,7 +1854,7 @@
             "octgnid": null,
             "value": "Clubs1",
             "url": "https://dtdb.co/en/card/00130",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00130.jpg"
+            "imagesrc": "/images/cards/en/00130.jpg"
         },
         {
             "last-modified": "2015-09-28T20:18:10+02:00",
@@ -1887,7 +1887,7 @@
             "octgnid": null,
             "value": "Clubs7",
             "url": "https://dtdb.co/en/card/00131",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00131.jpg"
+            "imagesrc": "/images/cards/en/00131.jpg"
         },
         {
             "last-modified": "2016-02-02T20:15:50+01:00",
@@ -1920,7 +1920,7 @@
             "octgnid": null,
             "value": "Spades6",
             "url": "https://dtdb.co/en/card/00132",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00132.jpg"
+            "imagesrc": "/images/cards/en/00132.jpg"
         },
         {
             "last-modified": "2015-02-09T11:01:58+01:00",
@@ -1953,7 +1953,7 @@
             "octgnid": null,
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/00133",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00133.jpg"
+            "imagesrc": "/images/cards/en/00133.jpg"
         },
         {
             "last-modified": "2021-01-27T02:29:12+01:00",
@@ -1986,7 +1986,7 @@
             "octgnid": null,
             "value": "Spades12",
             "url": "https://dtdb.co/en/card/00134",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00134.jpg"
+            "imagesrc": "/images/cards/en/00134.jpg"
         },
         {
             "last-modified": "2014-10-02T15:26:50+02:00",
@@ -2019,7 +2019,7 @@
             "octgnid": null,
             "value": "Diams8",
             "url": "https://dtdb.co/en/card/00135",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00135.jpg"
+            "imagesrc": "/images/cards/en/00135.jpg"
         },
         {
             "last-modified": "2015-09-28T20:00:16+02:00",
@@ -2052,7 +2052,7 @@
             "octgnid": null,
             "value": "Hearts7",
             "url": "https://dtdb.co/en/card/00136",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00136.jpg"
+            "imagesrc": "/images/cards/en/00136.jpg"
         },
         {
             "last-modified": "2015-09-28T20:18:53+02:00",
@@ -2085,7 +2085,7 @@
             "octgnid": null,
             "value": "Clubs3",
             "url": "https://dtdb.co/en/card/00137",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00137.jpg"
+            "imagesrc": "/images/cards/en/00137.jpg"
         },
         {
             "last-modified": "2015-10-11T17:17:54+02:00",
@@ -2118,7 +2118,7 @@
             "octgnid": null,
             "value": "Clubs12",
             "url": "https://dtdb.co/en/card/00138",
-            "imagesrc": "/web/bundles/dtdbcards/images/cards/en/00138.jpg"
+            "imagesrc": "/images/cards/en/00138.jpg"
         }
     ]
 }


### PR DESCRIPTION
the image paths will need adjustment with the upcoming dtdb update. while there's a rewrite rule in place that will prevent existing linkage from breaking, it's better to point at the new location.